### PR TITLE
Implement soft-delete by storing the deleted blobs index in Google Cloud Datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mvn:org.sonatype.nexus.plugins/nexus-blobstore-google-cloud/0.2.0-SNAPSHOT/xml/f
 Edit `${NEXUS_HOME}/system/org/sonatype/nexus/assemblies/nexus-core-feature/${NEXUS_VERSION}/nexus-core-feature-${NEXUS_VERSION}-features.xml`:
 
 ```xml
-<feature version="0.2.0-SNAPSHOT" prerequisite="false" dependency="false">nexus-blobstore-google-cloud</feature>
+<feature version="0.2.0.SNAPSHOT" prerequisite="false" dependency="false">nexus-blobstore-google-cloud</feature>
 ```
    
 That line should be added at about line 14, directly after:

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
   <version>0.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
+  <properties>
+    <google-cloud.version>1.35.0</google-cloud.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.sonatype.nexus</groupId>
@@ -35,9 +39,21 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-scheduling</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>1.35.0</version>
+      <version>${google-cloud.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>${google-cloud.version}</version>
     </dependency>
 
     <dependency>
@@ -87,6 +103,12 @@
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
+        <configuration>
+          <excludedArtifactIds combine.children="append">
+            <id>grpc-core</id>
+            <id>grpc-context</id>
+          </excludedArtifactIds>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/feature/feature.xml
+++ b/src/main/feature/feature.xml
@@ -4,5 +4,7 @@
     Relax protobuf import constraints so we can use latest release of Guava
     -->
     <bundle>wrap:${mvn:protobuf-java-util}$overwrite=merge&amp;Import-Package=com.google.common.*,*</bundle>
+    <bundle>wrap:${mvn:grpc-core}$Bundle-SymbolicName=grpc-core</bundle>
+    <bundle>wrap:${mvn:grpc-context}$Bundle-SymbolicName=grpc-context&amp;Fragment-Host=grpc-core</bundle>
   </feature>
 </features>

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
@@ -36,9 +36,9 @@ class DeletedBlobIndex
   /**
    * Add a {@link BlobId} to the index.
    */
-  void add(final BlobId blobId, final String reason) {
+  void add(final BlobId blobId) {
     Key key = deletedBlobsKeyFactory.newKey(blobId.asUniqueString());
-    Entity entity = Entity.newBuilder(key).set("reason", reason).build();
+    Entity entity = Entity.newBuilder(key).build();
     gcsDatastore.put(entity);
   }
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
@@ -1,0 +1,65 @@
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.sonatype.nexus.blobstore.api.BlobId;
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+
+/**
+ * Index of soft-deleted {@link BlobId}s, stored in Google Datastore.
+ */
+class DeletedBlobIndex
+{
+
+  private Datastore gcsDatastore;
+
+  private KeyFactory deletedBlobsKeyFactory;
+
+  private String deletedBlobsKeyKind;
+
+  DeletedBlobIndex(final GoogleCloudDatastoreFactory factory, final BlobStoreConfiguration blobStoreConfiguration) {
+    this.gcsDatastore = factory.create(blobStoreConfiguration);
+    this.deletedBlobsKeyKind = "NXRM-DeletedBlobs-" + blobStoreConfiguration.getName();
+    this.deletedBlobsKeyFactory = gcsDatastore.newKeyFactory().setKind(deletedBlobsKeyKind);
+  }
+
+  /**
+   * Add a {@link BlobId} to the index.
+   */
+  void add(final BlobId blobId, final String reason) {
+    Key key = deletedBlobsKeyFactory.newKey(blobId.asUniqueString());
+    Entity entity = Entity.newBuilder(key).set("reason", reason).build();
+    gcsDatastore.put(entity);
+  }
+
+  /**
+   * Remove a {@link BlobId} from the index
+   */
+  void remove(final BlobId blobId) {
+    gcsDatastore.delete(deletedBlobsKeyFactory.newKey(blobId.asUniqueString()));
+  }
+
+  /**
+   * @return a (finite) {@link Stream} of {@link BlobId}s that have been soft-deleted.
+   */
+  Stream<BlobId> getContents() {
+    Query<Entity> query = Query.newEntityQueryBuilder()
+        .setKind(this.deletedBlobsKeyKind)
+        .setLimit(10000)
+        .build();
+    QueryResults<Entity> results = gcsDatastore.run(query);
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(results, Spliterator.ORDERED),
+        false).map(entity -> new BlobId(entity.getKey().getName()));
+  }
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -262,7 +262,7 @@ public class GoogleCloudBlobStore
       blobAttributes.store();
 
       // add the blobId to the soft-deleted index
-      deletedBlobIndex.add(blobId, reason);
+      deletedBlobIndex.add(blobId);
       blob.markStale();
 
       return true;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2018-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import javax.inject.Named;
+
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+
+@Named
+public class GoogleCloudDatastoreFactory
+{
+
+  Datastore create(final BlobStoreConfiguration configuration) {
+    return DatastoreOptions.getDefaultInstance().getService();
+  }
+}

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -24,6 +24,8 @@ import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 import org.sonatype.nexus.blobstore.api.BlobStoreException
 
 import com.google.api.gax.paging.Page
+import com.google.cloud.datastore.Datastore
+import com.google.cloud.datastore.KeyFactory
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.Storage.BlobListOption
@@ -44,12 +46,18 @@ class GoogleCloudBlobStoreTest
 
   Bucket bucket = Mock()
 
+  GoogleCloudDatastoreFactory datastoreFactory = Mock()
+
+  Datastore datastore = Mock()
+
+  KeyFactory keyFactory = new KeyFactory("testing")
+
   def blobHeaders = [
       (BlobStore.BLOB_NAME_HEADER): 'test',
       (BlobStore.CREATED_BY_HEADER): 'admin'
   ]
   GoogleCloudBlobStore blobStore = new GoogleCloudBlobStore(
-      storageFactory, blobIdLocationResolver, metricsStore)
+      storageFactory, blobIdLocationResolver, metricsStore, datastoreFactory)
 
   def config = new BlobStoreConfiguration()
 
@@ -90,6 +98,9 @@ class GoogleCloudBlobStoreTest
     blobIdLocationResolver.fromHeaders(_) >> new BlobId(UUID.randomUUID().toString())
     storageFactory.create(_) >> storage
     config.attributes = [ 'google cloud storage': [bucket: 'mybucket'] ]
+
+    datastoreFactory.create(_) >> datastore
+    datastore.newKeyFactory() >> keyFactory
   }
 
   def 'initialize successfully from existing bucket'() {


### PR DESCRIPTION
This change set implements `Blobstore#delete(BlobId, String)`. An index of soft-deleted blobs are stored in as Entities in Google Cloud Datastore. These entities have the kind "NXRM-DeletedBlobs-<blobstorename>".
This change set also includes an implementation of `Blobstore#compact(BlobStoreUsageChecker)` that queries that index and iterates over a finite stream of deleted blobs, allowing this plugin to work with the [Admin - Compact blob store task](https://help.sonatype.com/repomanager3/configuration/system-configuration#SystemConfiguration-TypesofTasksandWhentoUseThem).

Fixes #2
