### PR TITLE
feat: encapsulate BlobAttributes, new Datastore option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>spock-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-blobstore-file</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -88,8 +88,6 @@ public class GoogleCloudBlobStore
 
   public static final String BUCKET_KEY = "bucket";
 
-  public static final String USE_DATASTORE_KEY = "use_datastore";
-
   static final String CREDENTIAL_FILE_KEY = "credential_file";
 
   private static final String BLOB_CONTENT_SUFFIX = ".bytes";

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -20,6 +20,7 @@ import javax.inject.Named;
 import org.sonatype.goodies.i18n.I18N;
 import org.sonatype.goodies.i18n.MessageBundle;
 import org.sonatype.nexus.blobstore.BlobStoreDescriptor;
+import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 
@@ -44,10 +45,17 @@ public class GoogleCloudBlobStoreDescriptor
 
     @DefaultMessage("Absolute path to Google Application Credentials JSON file")
     String credentialHelp();
+
+    @DefaultMessage("Store Attributes in Datastore")
+    String useDatastore();
+
+    @DefaultMessage("Store Blob Attributes in Google Datastore")
+    String useDatastoreHelp();
   }
 
   private final FormField bucket;
   private final FormField credentialFile;
+  private final FormField useDatastore;
 
   private static final Messages messages = I18N.create(Messages.class);
 
@@ -65,6 +73,13 @@ public class GoogleCloudBlobStoreDescriptor
         messages.credentialHelp(),
         FormField.OPTIONAL
     );
+
+    useDatastore = new CheckboxFormField(
+        GoogleCloudBlobStore.USE_DATASTORE_KEY,
+        messages.useDatastore(),
+        messages.useDatastoreHelp(),
+        FormField.MANDATORY
+    ).withInitialValue(true);
   }
 
   @Override
@@ -74,6 +89,6 @@ public class GoogleCloudBlobStoreDescriptor
 
   @Override
   public List<FormField> getFormFields() {
-    return Arrays.asList(bucket, credentialFile);
+    return Arrays.asList(bucket, credentialFile, useDatastore);
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -20,7 +20,6 @@ import javax.inject.Named;
 import org.sonatype.goodies.i18n.I18N;
 import org.sonatype.goodies.i18n.MessageBundle;
 import org.sonatype.nexus.blobstore.BlobStoreDescriptor;
-import org.sonatype.nexus.formfields.CheckboxFormField;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -45,17 +45,10 @@ public class GoogleCloudBlobStoreDescriptor
 
     @DefaultMessage("Absolute path to Google Application Credentials JSON file")
     String credentialHelp();
-
-    @DefaultMessage("Store Attributes in Datastore")
-    String useDatastore();
-
-    @DefaultMessage("Store Blob Attributes in Google Datastore")
-    String useDatastoreHelp();
   }
 
   private final FormField bucket;
   private final FormField credentialFile;
-  private final FormField useDatastore;
 
   private static final Messages messages = I18N.create(Messages.class);
 
@@ -73,13 +66,6 @@ public class GoogleCloudBlobStoreDescriptor
         messages.credentialHelp(),
         FormField.OPTIONAL
     );
-
-    useDatastore = new CheckboxFormField(
-        GoogleCloudBlobStore.USE_DATASTORE_KEY,
-        messages.useDatastore(),
-        messages.useDatastoreHelp(),
-        FormField.MANDATORY
-    ).withInitialValue(true);
   }
 
   @Override
@@ -89,6 +75,6 @@ public class GoogleCloudBlobStoreDescriptor
 
   @Override
   public List<FormField> getFormFields() {
-    return Arrays.asList(bucket, credentialFile, useDatastore);
+    return Arrays.asList(bucket, credentialFile);
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
@@ -31,7 +31,7 @@ import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.
 public class GoogleCloudDatastoreFactory extends AbstractGoogleClientFactory
 {
 
-  Datastore create(final BlobStoreConfiguration configuration) throws Exception {
+  public Datastore create(final BlobStoreConfiguration configuration) throws Exception {
     DatastoreOptions.Builder builder = DatastoreOptions.newBuilder().setTransportOptions(transportOptions());
 
     String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
@@ -13,7 +13,6 @@
 package org.sonatype.nexus.blobstore.gcloud.internal;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 
 import javax.inject.Named;
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
@@ -18,19 +18,9 @@ import javax.inject.Named;
 
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
 
-import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.cloud.TransportOptions;
-import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingClientConnectionManager;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.CoreConnectionPNames;
 import org.apache.shiro.util.StringUtils;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
@@ -30,7 +30,7 @@ import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.
 public class GoogleCloudStorageFactory extends AbstractGoogleClientFactory
 {
 
-  Storage create(final BlobStoreConfiguration configuration) throws Exception {
+  public Storage create(final BlobStoreConfiguration configuration) throws Exception {
     StorageOptions.Builder builder = StorageOptions.newBuilder().setTransportOptions(transportOptions());
 
     String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/BlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/BlobAttributesDao.java
@@ -1,0 +1,29 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.sonatype.nexus.blobstore.api.BlobAttributes;
+import org.sonatype.nexus.blobstore.api.BlobId;
+import org.sonatype.nexus.blobstore.api.BlobMetrics;
+
+/**
+ * Used internally by {@link org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore} to encapsulate
+ * maintenance of {@link BlobAttributes}.
+ */
+public interface BlobAttributesDao
+{
+  @Nullable
+  BlobAttributes getAttributes(BlobId blobId);
+
+  void deleteAttributes(BlobId blobId);
+
+  void markDeleted(BlobId blobId, String reason);
+
+  void undelete(BlobId blobId);
+
+  BlobAttributes storeAttributes(BlobId blobId, BlobAttributes blobAttributes);
+
+  BlobAttributes storeAttributes(BlobId blobId, Map<String, String> headers, BlobMetrics metrics);
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/BlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/BlobAttributesDao.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
 
 import java.util.Map;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
@@ -152,6 +152,7 @@ class DatastoreBlobAttributesDao
 
     protected GCBlobAttributes(Map<String, String> headers, BlobMetrics metrics) {
       super(new Properties(), headers, metrics);
+      writeTo(propertiesFile);
     }
 
     @Override

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
@@ -1,0 +1,161 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.annotation.Nullable;
+
+import org.sonatype.nexus.blobstore.BlobAttributesSupport;
+import org.sonatype.nexus.blobstore.api.BlobAttributes;
+import org.sonatype.nexus.blobstore.api.BlobId;
+import org.sonatype.nexus.blobstore.api.BlobMetrics;
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributes;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Entity.Builder;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
+import com.google.common.annotations.VisibleForTesting;
+
+import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.DELETED_ATTRIBUTE;
+import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.DELETED_REASON_ATTRIBUTE;
+
+/**
+ * {@link BlobAttributesDao} backed by Google Cloud {@link Datastore}.
+ */
+class DatastoreBlobAttributesDao
+  implements BlobAttributesDao
+{
+
+  private Datastore gcsDatastore;
+
+  private KeyFactory keyFactory;
+
+  private String attributesKeyKind;
+
+  DatastoreBlobAttributesDao(final Datastore datastore, final BlobStoreConfiguration configuration) {
+    this.gcsDatastore = datastore;
+    this.attributesKeyKind = "NXRM-BlobAttributes-" + configuration.getName();
+    this.keyFactory = gcsDatastore.newKeyFactory().setKind(attributesKeyKind);
+  }
+
+  @VisibleForTesting
+  String getAttributesKeyKind() {
+    return attributesKeyKind;
+  }
+
+  @Override
+  public BlobAttributes getAttributes(final BlobId blobId) {
+    return from(attributesEntity(blobId));
+  }
+
+  @Override
+  public void deleteAttributes(final BlobId blobId) {
+    Entity attributes = attributesEntity(blobId);
+    if (attributes != null) {
+      gcsDatastore.delete(attributes.getKey());
+    }
+  }
+
+  @Override
+  public void markDeleted(final BlobId blobId, final String reason) {
+    BlobAttributes attributes = getAttributes(blobId);
+    if (attributes != null) {
+      attributes.setDeleted(true);
+      attributes.setDeletedReason(reason);
+
+      storeAttributes(blobId, attributes);
+    }
+  }
+
+  @Override
+  public void undelete(final BlobId blobId) {
+    BlobAttributes attributes = getAttributes(blobId);
+    if (attributes != null) {
+      attributes.setDeleted(false);
+      attributes.setDeletedReason(null);
+
+      storeAttributes(blobId, attributes);
+    }
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(final BlobId blobId, final BlobAttributes blobAttributes) {
+    Key key = keyFactory.newKey(blobId.asUniqueString());
+    Builder builder = Entity.newBuilder(key);
+
+    Properties props = blobAttributes.getProperties();
+    if (blobAttributes.isDeleted()) {
+      props.put(DELETED_ATTRIBUTE, Boolean.TRUE.toString());
+      props.put(DELETED_REASON_ATTRIBUTE, blobAttributes.getDeletedReason());
+    }
+
+    props.stringPropertyNames()
+        .stream().forEach(name -> builder.set(name, props.getProperty(name)));
+
+    // TODO catch DatastoreException and wrap in BlobStoreException?
+    Entity result = gcsDatastore.put(builder.build());
+    return from(result);
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(final BlobId blobId, final Map<String, String> headers,
+                                        final BlobMetrics metrics) {
+    return storeAttributes(blobId, new GCBlobAttributes(headers, metrics));
+  }
+
+  Entity attributesEntity(final BlobId blobId) {
+    Query<Entity> query = Query.newEntityQueryBuilder()
+        .setKind(this.attributesKeyKind)
+        .setFilter(PropertyFilter.eq("__key__", keyFactory.newKey(blobId.asUniqueString())))
+        .build();
+    QueryResults<Entity> results = gcsDatastore.run(query);
+    if (results.hasNext()) {
+      return results.next();
+    }
+    return null;
+  }
+
+  @Nullable
+  GCBlobAttributes from(Entity entity) {
+    if (entity == null) {
+      return null;
+    }
+    Properties properties = new Properties();
+    entity.getNames().forEach(n -> properties.setProperty(n, entity.getString(n)));
+
+    GCBlobAttributes result = new GCBlobAttributes(properties);
+    result.readFrom(properties);
+
+    return result;
+  }
+
+  class GCBlobAttributes extends BlobAttributesSupport<Properties> {
+
+    protected GCBlobAttributes(final Properties propertiesFile)
+    {
+      super(propertiesFile, null, null);
+    }
+
+    protected GCBlobAttributes(Map<String, String> headers, BlobMetrics metrics) {
+      super(new Properties(), headers, metrics);
+    }
+
+    @Override
+    public void store() {
+      writeTo(propertiesFile);
+      // TODO need a reference to the Dao to write this out?
+    }
+
+    @Override
+    public void readFrom(final Properties properties) {
+      super.readFrom(properties);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDao.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
 
 import java.util.Map;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
@@ -1,0 +1,115 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
+
+import java.util.Map;
+
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.blobstore.BlobIdLocationResolver;
+import org.sonatype.nexus.blobstore.api.BlobAttributes;
+import org.sonatype.nexus.blobstore.api.BlobId;
+import org.sonatype.nexus.blobstore.api.BlobMetrics;
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.common.stateguard.Guarded;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
+import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
+
+/**
+ * Bridge implementation of {@link BlobAttributesDao} for determining whether to use Google Cloud Datastore
+ * or Google Cloud Storage properties files for {@link BlobAttributes} storage.
+ */
+public final class GoogleCloudBlobAttributesBridge
+    extends ComponentSupport
+    implements BlobAttributesDao
+{
+
+  private final boolean useDatastore;
+
+  private final PropertiesFileBlobAttributesDao propertiesDao;
+
+  private final DatastoreBlobAttributesDao datastoreDao;
+
+
+  /**
+   *
+   * @param blobStoreConfiguration
+   * @param blobIdLocationResolver
+   * @param useDatastore
+   * @param datastore
+   * @param bucket
+   * @param storage
+   */
+  public GoogleCloudBlobAttributesBridge(final BlobStoreConfiguration blobStoreConfiguration,
+                                         final BlobIdLocationResolver blobIdLocationResolver,
+                                         final boolean useDatastore,
+                                         final Datastore datastore,
+                                         final Bucket bucket,
+                                         final Storage storage) {
+    this.useDatastore = useDatastore;
+    String bucketName = blobStoreConfiguration.attributes(CONFIG_KEY).require(BUCKET_KEY).toString();
+    this.propertiesDao = new PropertiesFileBlobAttributesDao(blobIdLocationResolver, bucket, storage,
+        blobStoreConfiguration, bucketName);
+    this.datastoreDao = new DatastoreBlobAttributesDao(datastore, blobStoreConfiguration);
+  }
+
+  @Override
+  public BlobAttributes getAttributes(BlobId blobId) {
+    if (useDatastore) {
+      return datastoreDao.getAttributes(blobId);
+    } else {
+      return propertiesDao.getAttributes(blobId);
+    }
+  }
+
+  @Override
+  public void deleteAttributes(BlobId blobId) {
+    if (useDatastore) {
+      datastoreDao.deleteAttributes(blobId);
+    } else {
+      propertiesDao.deleteAttributes(blobId);
+    }
+  }
+
+  @Override
+  public void markDeleted(BlobId blobId, String reason) {
+    if (useDatastore) {
+      datastoreDao.markDeleted(blobId, reason);
+    } else {
+      propertiesDao.markDeleted(blobId, reason);
+    }
+  }
+
+  @Override
+  public void undelete(final BlobId blobId) {
+    if (useDatastore) {
+      datastoreDao.undelete(blobId);
+    } else {
+      propertiesDao.undelete(blobId);
+    }
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(BlobId blobId, BlobAttributes blobAttributes) {
+    if (useDatastore) {
+      return datastoreDao.storeAttributes(blobId, blobAttributes);
+    } else {
+      return propertiesDao.storeAttributes(blobId, blobAttributes);
+    }
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(final BlobId blobId,
+                                        final Map<String, String> headers,
+                                        final BlobMetrics metrics)
+  {
+    if (useDatastore) {
+      return datastoreDao.storeAttributes(blobId, headers, metrics);
+    } else {
+      return propertiesDao.storeAttributes(blobId, headers, metrics);
+    }
+  }
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
@@ -8,7 +8,6 @@ import org.sonatype.nexus.blobstore.api.BlobAttributes;
 import org.sonatype.nexus.blobstore.api.BlobId;
 import org.sonatype.nexus.blobstore.api.BlobMetrics;
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
-import org.sonatype.nexus.common.stateguard.Guarded;
 
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.storage.Bucket;
@@ -16,7 +15,6 @@ import com.google.cloud.storage.Storage;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
 import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
 
 /**
  * Bridge implementation of {@link BlobAttributesDao} for determining whether to use Google Cloud Datastore

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/GoogleCloudBlobAttributesBridge.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
 
 import java.util.Map;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDao.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
 
 import java.io.IOException;

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDao.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDao.java
@@ -1,0 +1,166 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.blobstore.BlobIdLocationResolver;
+import org.sonatype.nexus.blobstore.api.BlobAttributes;
+import org.sonatype.nexus.blobstore.api.BlobId;
+import org.sonatype.nexus.blobstore.api.BlobMetrics;
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.blobstore.api.BlobStoreException;
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributes;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONTENT_PREFIX;
+
+/**
+ * {@link BlobAttributesDao} backed by {@link org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudPropertiesFile}s
+ * in the Google Cloud Storage bucket.
+ */
+class PropertiesFileBlobAttributesDao
+    extends ComponentSupport
+    implements BlobAttributesDao
+{
+  public static final String BLOB_ATTRIBUTE_SUFFIX = ".properties";
+
+  private BlobIdLocationResolver blobIdLocationResolver;
+
+  private BlobStoreConfiguration blobStoreConfiguration;
+
+  private final Bucket bucket;
+
+  private final String bucketName;
+
+  private final Storage storage;
+
+  public PropertiesFileBlobAttributesDao(final BlobIdLocationResolver blobIdLocationResolver,
+                                         final Bucket bucket,
+                                         final Storage storage,
+                                         final BlobStoreConfiguration blobStoreConfiguration,
+                                         final String bucketName) {
+    this.blobIdLocationResolver = blobIdLocationResolver;
+    this.bucket = bucket;
+    this.storage = storage;
+
+    this.blobStoreConfiguration = blobStoreConfiguration;
+    this.bucketName = bucketName;
+  }
+
+  @Override
+  public GoogleCloudBlobAttributes getAttributes(BlobId blobId) {
+    GoogleCloudBlobAttributes blobAttributes = new GoogleCloudBlobAttributes(bucket, attributePath(blobId));
+    try {
+      boolean loaded = blobAttributes.load();
+      if (!loaded) {
+        log.warn("Attempt to access non-existent blob {} ({})", blobId, blobAttributes);
+        return null;
+      }
+
+      return blobAttributes;
+    } catch (IOException e) {
+      log.error("Unable to load GoogleCloudBlobAttributes for blob id: {}", blobId, e);
+      throw new BlobStoreException(e, blobId);
+    }
+  }
+
+  @Override
+  public void deleteAttributes(BlobId blobId) {
+    storage.delete(bucketName, attributePath(blobId));
+  }
+
+  @Override
+  public void markDeleted(BlobId blobId, String reason) {
+    GoogleCloudBlobAttributes blobAttributes = new GoogleCloudBlobAttributes(bucket, attributePath(blobId));
+
+    try {
+      boolean loaded = blobAttributes.load();
+      if (!loaded) {
+        log.warn("Attempt to mark-for-delete non-existent blob {}", blobId);
+      }
+      else if (blobAttributes.isDeleted()) {
+        log.debug("Attempt to delete already-deleted blob {}", blobId);
+      }
+
+      blobAttributes.setDeleted(true);
+      blobAttributes.setDeletedReason(reason);
+      blobAttributes.store();
+    } catch (IOException e) {
+      throw new BlobStoreException(e, blobId);
+    }
+  }
+
+  @Override
+  public void undelete(BlobId blobId) {
+    GoogleCloudBlobAttributes blobAttributes = new GoogleCloudBlobAttributes(bucket, attributePath(blobId));
+
+    try {
+      boolean loaded = blobAttributes.load();
+      if (!loaded) {
+        log.warn("Attempt to undelete non-existent blob {}", blobId);
+      }
+
+      blobAttributes.setDeleted(false);
+      blobAttributes.setDeletedReason(null);
+      blobAttributes.store();
+    } catch (IOException e) {
+      throw new BlobStoreException(e, blobId);
+    }
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(BlobId blobId, BlobAttributes blobAttributes) {
+    return storeAttributes(blobId, blobAttributes.getHeaders(), blobAttributes.getMetrics());
+  }
+
+  @Override
+  public BlobAttributes storeAttributes(final BlobId blobId,
+                                        final Map<String, String> headers,
+                                        final BlobMetrics metrics)
+  {
+    final String attributePath = attributePath(blobId);
+    GoogleCloudBlobAttributes attributes = new GoogleCloudBlobAttributes(bucket, attributePath,
+        headers, metrics);
+
+    try {
+      attributes.store();
+    }
+    catch (IOException e) {
+      deleteNonExplosively(attributePath);
+      throw new BlobStoreException(e, blobId);
+    }
+
+    return attributes;
+  }
+
+  /**
+   * Returns path for blob-id attribute file relative to root directory.
+   */
+  private String attributePath(final BlobId id) {
+    return getLocation(id) + BLOB_ATTRIBUTE_SUFFIX;
+  }
+
+  /**
+   * Returns the location for a blob ID based on whether or not the blob ID is for a temporary or permanent blob.
+   */
+  private String getLocation(final BlobId id) {
+    return CONTENT_PREFIX + "/" + blobIdLocationResolver.getLocation(id);
+  }
+
+  /**
+   * Intended for use only within catch blocks that intend to throw their own {@link BlobStoreException}
+   * for another good reason.
+   *
+   * @param contentPath the path within the configured bucket to delete
+   */
+  private void deleteNonExplosively(final String contentPath) {
+    try {
+      storage.delete(bucketName, contentPath);
+    } catch (Exception e) {
+      log.warn("caught exception attempting to delete during cleanup", e);
+    }
+  }
+}

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
@@ -73,9 +73,11 @@ class GoogleCloudBlobStoreIT
 
   def setup() {
     config.attributes = [
+        'name': 'gcs-test',
         'google cloud storage': [
             bucket: bucketName,
-            credential_file: this.getClass().getResource('/gce-credentials.json').getFile()
+            credential_file: this.getClass().getResource('/gce-credentials.json').getFile(),
+            use_datastore: 'false'
         ]
     ]
 

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
@@ -83,7 +83,6 @@ class GoogleCloudBlobStoreIT
         'google cloud storage': [
             bucket: bucketName,
             credential_file: this.getClass().getResource('/gce-credentials.json').getFile(),
-            use_datastore: 'false'
         ]
     ]
 

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -175,7 +175,6 @@ class GoogleCloudBlobStoreTest
       storage.get('mybucket') >> bucket
       blobStore.init(config)
       blobStore.doStart()
-      //bucket.get('content/existing.properties', _) >> mockGoogleObject(tempFileAttributes)
       bucket.get('content/existing.bytes', _) >> mockGoogleObject(tempFileBytes)
       datastore.run(_) >> mockQueryResults(mockEntity())
 
@@ -192,9 +191,7 @@ class GoogleCloudBlobStoreTest
       blobStore.init(config)
       blobStore.doStart()
       def b1 = com.google.cloud.storage.BlobId.of('foo', 'notundercontent.txt')
-      //def b2 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-01/chap-08/thing.properties')
       def b3 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-01/chap-08/thing.bytes')
-      //def b4 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-02/chap-09/tmp$thing.properties')
       def b5 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-02/chap-09/tmp$thing.bytes')
       def page = Mock(Page)
 
@@ -244,7 +241,6 @@ class GoogleCloudBlobStoreTest
       storage.get('mybucket') >> bucket
       blobStore.init(config)
       blobStore.doStart()
-      //bucket.get('content/existing.properties', _) >> mockGoogleObject(tempFileAttributes)
       datastore.run(_) >> mockQueryResults(mockEntity())
 
     when: 'call exists'
@@ -273,7 +269,6 @@ class GoogleCloudBlobStoreTest
       storage.get('mybucket') >> bucket
       blobStore.init(config)
       blobStore.doStart()
-      //bucket.get('content/existing.properties', _) >> { throw new IOException("this is a test") }
       datastore.run(_) >> { throw new DatastoreException(new IOException("this is a test")) }
 
     when: 'call exists'

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -29,7 +29,6 @@ import com.google.cloud.datastore.Datastore
 import com.google.cloud.datastore.DatastoreException
 import com.google.cloud.datastore.Entity
 import com.google.cloud.datastore.KeyFactory
-import com.google.cloud.datastore.Query
 import com.google.cloud.datastore.QueryResults
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.Storage

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -98,7 +98,7 @@ class GoogleCloudBlobStoreTest
     blobIdLocationResolver.getLocation(_) >> { args -> args[0].toString() }
     blobIdLocationResolver.fromHeaders(_) >> new BlobId(UUID.randomUUID().toString())
     storageFactory.create(_) >> storage
-    config.attributes = [ 'google cloud storage': [bucket: 'mybucket'] ]
+    config.attributes = [ 'google cloud storage': [ bucket: 'mybucket', use_datastore: 'false'] ]
 
     datastoreFactory.create(_) >> datastore
     datastore.newKeyFactory() >> keyFactory
@@ -163,11 +163,13 @@ class GoogleCloudBlobStoreTest
       def b2 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-01/chap-08/thing.properties')
       def b3 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-01/chap-08/thing.bytes')
       def b4 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-02/chap-09/tmp$thing.properties')
+      def b5 = com.google.cloud.storage.BlobId.of('foo', 'content/vol-02/chap-09/tmp$thing.bytes')
       def page = Mock(Page)
 
       bucket.list(BlobListOption.prefix(GoogleCloudBlobStore.CONTENT_PREFIX)) >> page
       page.iterateAll() >>
-          [ mockGoogleObject(b1), mockGoogleObject(b2), mockGoogleObject(b3), mockGoogleObject(b4) ]
+          [ mockGoogleObject(b1), mockGoogleObject(b2), mockGoogleObject(b3), mockGoogleObject(b4),
+            mockGoogleObject(b5) ]
 
     when: 'getBlobIdStream called'
       Stream<BlobId> stream = blobStore.getBlobIdStream()
@@ -175,7 +177,7 @@ class GoogleCloudBlobStoreTest
     then: 'expected behavior'
       def list = stream.collect(Collectors.toList())
       list.size() == 1
-      list.contains(new BlobId(b2.toString()))
+      list.contains(new BlobId(b3.toString()))
   }
 
   def 'start will accept a metadata.properties originally created with file blobstore'() {

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDaoIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDaoIT.groovy
@@ -1,0 +1,112 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes
+
+import java.nio.file.FileSystems
+
+import org.sonatype.nexus.blobstore.api.BlobAttributes
+import org.sonatype.nexus.blobstore.api.BlobId
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
+import org.sonatype.nexus.blobstore.file.FileBlobAttributes
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudDatastoreFactory
+
+import com.google.cloud.datastore.Datastore
+import com.google.cloud.datastore.Entity
+import com.google.cloud.datastore.Query
+import com.google.cloud.datastore.QueryResults
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+class DatastoreBlobAttributesDaoIT
+  extends Specification
+{
+  static final Logger log = LoggerFactory.getLogger(DatastoreBlobAttributesDaoIT.class)
+
+  static final String testUniqueID = UUID.randomUUID().toString()
+
+  static final BlobStoreConfiguration config = new BlobStoreConfiguration()
+
+  static File tempFileAttributes
+
+  DatastoreBlobAttributesDao attributesDao
+
+  def setupSpec() {
+    config.attributes = [
+        'google cloud storage': [
+            credential_file: this.getClass().getResource('/gce-credentials.json').getFile()
+        ]
+    ]
+    config.name = testUniqueID
+
+    tempFileAttributes = File.createTempFile('gcloudtest', 'properties')
+    tempFileAttributes << """\
+      |@BlobStore.created-by=admin
+      |size=32
+      |@Bucket.repo-name=maven-snapshots
+      |creationTime=1535056281314
+      |@BlobStore.created-by-ip=127.0.0.1
+      |@BlobStore.content-type=text/plain
+      |@BlobStore.blob-name=local/sonatype/group1/test-project/0.10.0-SNAPSHOT/test-project-0.10.0-20180823.203101-1.pom.md5
+      |sha1=4f0fc3951c87bae5a38f53c4f872ad0fb9faef54
+    """.stripMargin()
+
+    log.info("attributes for test will be stored with key kind suffix {}", testUniqueID)
+  }
+  def setup() {
+    Datastore datastore = new GoogleCloudDatastoreFactory().create(config)
+
+    attributesDao = new DatastoreBlobAttributesDao(datastore, config)
+  }
+
+  def cleanupSpec() {
+    Datastore datastore = new GoogleCloudDatastoreFactory().create(config)
+    DatastoreBlobAttributesDao dao = new DatastoreBlobAttributesDao(datastore, config)
+    Query<Entity> query = Query.newEntityQueryBuilder()
+        .setKind(dao.attributesKeyKind)
+        .build()
+    QueryResults<Entity> results = datastore.run(query)
+    log.info("deleting attributes created under key kind {}", dao.attributesKeyKind)
+    while (results.hasNext()) {
+      datastore.delete(results.next().getKey())
+    }
+    log.info('cleanupSpec complete')
+  }
+
+  def 'storeAttributes successfully stores properties'() {
+    given:
+      BlobId id = new BlobId('testing')
+      BlobAttributes blobAttributes = new FileBlobAttributes(FileSystems.getDefault().getPath(tempFileAttributes.getPath()))
+      assert blobAttributes.load()
+      assert blobAttributes.metrics != null
+
+    when:
+      BlobAttributes stored = attributesDao.storeAttributes(id, blobAttributes)
+
+    then:
+      stored != null
+      BlobAttributes readback = attributesDao.getAttributes(id)
+      readback != null
+      stored.headers == readback.headers
+      stored.metrics.contentSize == readback.metrics.contentSize
+      stored.metrics.creationTime == readback.metrics.creationTime
+      stored.metrics.sha1Hash == readback.metrics.sha1Hash
+  }
+
+  def 'markDeleted successfully sets deleted'() {
+    given:
+      BlobId id = new BlobId('testing2')
+      BlobAttributes blobAttributes = new FileBlobAttributes(FileSystems.getDefault().getPath(tempFileAttributes.getPath()))
+      assert blobAttributes.load()
+      assert blobAttributes.metrics != null
+      assert !blobAttributes.deleted
+      assert attributesDao.storeAttributes(id, blobAttributes) != null
+
+    when:
+      attributesDao.markDeleted(id, 'testreason')
+
+    then:
+      BlobAttributes readback = attributesDao.getAttributes(id)
+      readback != null
+      readback.deleted
+      readback.deletedReason =='testreason'
+  }
+}

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDaoIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/DatastoreBlobAttributesDaoIT.groovy
@@ -45,7 +45,6 @@ class DatastoreBlobAttributesDaoIT
   def conditions = new PollingConditions(timeout: 5, initialDelay: 0, factor: 1)
 
   def setupSpec() {
-    config.name = 'DatabaseBlobAttributesDaoIT'
     config.attributes = [
         'google cloud storage': [
             credential_file: this.getClass().getResource('/gce-credentials.json').getFile()

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDaoIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/attributes/PropertiesFileBlobAttributesDaoIT.groovy
@@ -1,0 +1,40 @@
+package org.sonatype.nexus.blobstore.gcloud.internal.attributes
+
+import org.sonatype.nexus.blobstore.BlobIdLocationResolver
+import org.sonatype.nexus.blobstore.DefaultBlobIdLocationResolver
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudStorageFactory
+
+import com.google.cloud.storage.Bucket
+import spock.lang.Specification
+
+class PropertiesFileBlobAttributesDaoIT
+  extends Specification
+{
+  BlobIdLocationResolver locationResolver = new DefaultBlobIdLocationResolver()
+
+  final static GoogleCloudStorageFactory storageFactory = new GoogleCloudStorageFactory()
+
+  PropertiesFileBlobAttributesDao attributesDao
+
+  final static BlobStoreConfiguration config = new BlobStoreConfiguration()
+
+  static Bucket bucket
+
+  def setupSpec() {
+    // create storage and bucket
+  }
+
+  def setup() {
+    config.attributes = [
+        'google cloud storage': [
+            credential_file: this.getClass().getResource('/gce-credentials.json').getFile()
+        ]
+    ]
+    config.name = 'PropertiesFileBlobAttributesDaoIT'
+
+    def storage = storageFactory.create(config)
+
+    attributesDao = new PropertiesFileBlobAttributesDao(locationResolver, bucket, storage, config, bucketName)
+  }
+}


### PR DESCRIPTION
Work in progress to persist BlobAttributes in Google Cloud Datastore as an option (instead of just .properties file in the bucket).

TODO:

- [x] Maybe check the blobstore metadata first instead of publishing as a user facing option? If it's file, use .properties, if not present, use datastore
- [ ] Update ITs to run through both .properties and datastore

