### PR TITLE
update to NXRM 3.14 and latest Google Cloud Storage library

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nexus Repository Google Cloud Storage Blobstore
 [![Build Status](https://travis-ci.org/sonatype-nexus-community/nexus-blobstore-google-cloud.svg?branch=master)](https://travis-ci.org/sonatype-nexus-community/nexus-blobstore-google-cloud) [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This project adds [Google Cloud Object Storage](https://cloud.google.com/storage/) backed blobstores to Sonatype Nexus 
-Repository 3.13 and later.  It allows Nexus Repository to store the components and assets in Google Cloud instead of a
+Repository 3.14 and later.  It allows Nexus Repository to store the components and assets in Google Cloud instead of a
 local filesystem.
 
 Contribution Guidelines

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.13.0-01</version>
+    <version>3.14.0-04</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud</artifactId>
@@ -30,7 +30,7 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <google-cloud.version>1.35.0</google-cloud.version>
+    <google-cloud.version>1.49.0</google-cloud.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreMetricsStore.java
@@ -30,6 +30,7 @@ import org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -134,7 +135,7 @@ public class GoogleCloudBlobStoreMetricsStore
 
   private BlobStoreMetrics getCombinedMetrics(final Stream<GoogleCloudPropertiesFile> blobStoreMetricsFiles) {
     AccumulatingBlobStoreMetrics blobStoreMetrics = new AccumulatingBlobStoreMetrics(0, 0,
-        Long.MAX_VALUE, true);
+        ImmutableMap.of("gcp", Long.MAX_VALUE), true);
 
     blobStoreMetricsFiles.forEach(metricsFile -> {
       try {

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
@@ -114,6 +114,16 @@ class GoogleCloudBlobStoreIT
     log.info("Integration test complete, bucket ${bucketName} deleted")
   }
 
+  def "isWritable true for buckets created by the Integration Test"() {
+    expect:
+      blobStore.isWritable()
+  }
+
+  def "isGroupable is true"() {
+    expect:
+      blobStore.isGroupable()
+  }
+
   def "getDirectPathBlobIdStream returns empty stream for missing prefix"() {
     given:
 


### PR DESCRIPTION
This pull request makes the following changes:

* Updates the minimum version of NXRM to 3.14.
* Updates the google-cloud-storage dependency to the latest version.

The `BlobStore` interface in NXRM 3.14 includes a new method to test if the blobstore is in fact writable. The implementation defines that the blobstore is writable if the IAM permissions includes both `[ storage.objects.create, storage.objects.delete ]`.

