### PR TITLE
Experiment: Parallel Multipart Upload

### DIFF
--- a/design/multipart_parallel_upload.md
+++ b/design/multipart_parallel_upload.md
@@ -1,0 +1,36 @@
+# Multipart Parallel Upload Design
+
+This document is intended to capture the context around the component within this blobstore that provides 
+Parallel Multipart Upload:
+
+[MultipartUploader.java](../src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java)
+
+## Context and Idea
+
+gsutil concept: [Parallel Composite Uploads](https://cloud.google.com/storage/docs/gsutil/commands/cp#parallel-composite-uploads)
+
+The google-cloud-storage library for Java this blobstore is built with does not have baked in mechanism for parallel composite uploads.
+The storage#create function is synchronous. Fine for some workloads
+
+It does support however, the Compose request in the API. 
+This module then implements this client using the Storage request and Compose request functions.
+
+## Implementation
+
+* Don't have content length in the API, have a stream.
+* GCS compose method has a hard limit of 32. Since we don't have the length, we can't
+split into 32 equal parts. We can do 31 chunks of a chunkSize parameter, then 1 chunk of the rest.
+* Exposes the "composeLimitHit" field
+* For files smaller than the chunk size, we don't pay the cost of shipping the upload request to a thread.
+    * The first chunk is written at the expected destination path.
+    * If we've read chunkSize, and there is still more data on the stream, schedule the 2nd through final chunks off thread
+* A blob write still waits until completion of parallel uploads. This is an important characteristic of all BlobStores; 
+Nexus Repository Manager expects consistency and not deferred, eventual consistency.
+
+## Tuning
+
+* debug logging for `org.sonatype.nexus.blobstore.gcloud.internal.MultipartUploader`
+* 5 MB default and 32 chunk compose limit means optimal threads utilization will be in place for files between 10 MB 
+and 160 MB in size.
+* When to increase? When you have fewer CPUs, and larger files.
+* To effectively disable parallel uploads, you could put max int in. Will upload on the request thread

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-repository</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/AbstractGoogleClientFactory.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/AbstractGoogleClientFactory.java
@@ -16,9 +16,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.ProxySelector;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.cloud.TransportOptions;
@@ -79,7 +76,7 @@ public abstract class AbstractGoogleClientFactory
     HttpConnectionParams.setStaleCheckingEnabled(params, true);
     HttpConnectionParams.setSocketBufferSize(params, 8192);
     ConnManagerParams.setMaxTotalConnections(params, 200);
-    ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(20));
+    ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(200));
     return params;
   }
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -179,17 +179,6 @@ public class GoogleCloudBlobStore
         MetricsInputStream input = new MetricsInputStream(data);
 
         multipartUploader.upload(storage, getConfiguredBucketName(), destination, input);
-       /* BlobInfo blobInfo = BlobInfo.newBuilder(getConfiguredBucketName(), destination).build();
-        try (WriteChannel writeChannel = storage.writer(blobInfo)) {
-          int limit;
-          // 1024 vs 1048576
-          byte[] buffer = new byte[1048576];
-          while ((limit = input.read(buffer)) >= 0) {
-            writeChannel.write(ByteBuffer.wrap(buffer, 0, limit));
-          }
-        }*/
-
-        //bucket.create(destination, input);
         return input.getMetrics();
       }
     });

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
@@ -1,0 +1,205 @@
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.sonatype.nexus.blobstore.api.BlobStoreException;
+import org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.ComposeRequest;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Component that provides parallel multipart upload support for blob binary data (.bytes files).
+ */
+@Named
+public class MultipartUploader
+    extends StateGuardLifecycleSupport
+{
+
+  /**
+   * Use this property in 'nexus.properties' to control how large each multipart part is. Default is 5 MB.
+   * Smaller numbers increase the number of parallel workers used to upload a file. Match to your workload:
+   * if you are heavy in docker with large images, increase; if you are heavy in smaller components, decrease.
+   */
+  public static final String CHUNK_SIZE_PROPERTY = "nexus.gcs.multipartupload.chunksize";
+
+  /**
+   * This is a hard limit on the number of components to a compose request enforced by Google Cloud Storage API.
+   */
+  static final int COMPOSE_REQUEST_LIMIT = 32;
+
+  /**
+   * While an invocation of {@link #upload(Storage, String, String, InputStream)} is in-flight, the individual
+   * chunks of the file will have names like 'destination.chunkPartNumber", like
+   * 'content/vol-01/chap-01/UUID.bytes.chunk1', 'content/vol-01/chap-01/UUID.bytes.chunk2', etc.
+   */
+  private final String CHUNK_NAME_PART = ".chunk";
+
+  /**
+   * Used internally to count how many times we've hit the compose limit.
+   * Consider exposing this as a bean that can provide tuning feedback to deployers.
+   */
+  private final AtomicLong composeLimitHit = new AtomicLong(0);
+
+  private static final byte[] EMPTY = new byte[0];
+
+  private final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat("nexus-google-cloud-storage-multipart-upload-%d")
+              .build()));
+
+  private final int chunkSize;
+
+  @Inject
+  public MultipartUploader(@Named("${"+CHUNK_SIZE_PROPERTY +":-5242880}") final int chunkSize) {
+    this.chunkSize = chunkSize;
+  }
+
+  @Override
+  protected void doStop() throws Exception {
+    executorService.shutdown();
+    log.info("sent signal to shutdown multipart upload queue, waiting up to 3 minutes for termination...");
+    executorService.awaitTermination(3L, TimeUnit.MINUTES);
+  }
+
+  /**
+   * @return the value for the {@link #CHUNK_SIZE_PROPERTY}
+   */
+  public int getChunkSize() {
+    return chunkSize;
+  }
+
+  /**
+   * @return the number of times {@link #upload(Storage, String, String, InputStream)} hit the multipart-compose limit
+   */
+  public long getNumberOfTimesComposeLimitHit() {
+    return composeLimitHit.get();
+  }
+
+  /**
+   * @param storage an initialized {@link Storage} instance
+   * @param bucket the name of the bucket
+   * @param destination the the destination (relative to the bucket)
+   * @param contents the stream of data to store
+   * @return the successfully stored {@link Blob}
+   * @throws BlobStoreException if any part of the upload failed
+   */
+  public Blob upload(final Storage storage, final String bucket, final String destination, final InputStream contents) {
+    log.debug("Starting multipart upload for destination {} in bucket {}", destination, bucket);
+    // collect parts as blobids in a list?
+    List<String> parts = new ArrayList<>();
+
+    try (InputStream current = contents) {
+      List<ListenableFuture<Blob>> chunkFutures = new ArrayList<>();
+      // MUST respect hard limit of 32 chunks per compose request
+      for (int partNumber = 1; partNumber <= COMPOSE_REQUEST_LIMIT; partNumber++) {
+        final byte[] chunk;
+        if (partNumber < COMPOSE_REQUEST_LIMIT) {
+          chunk = readChunk(current);
+        }
+        else {
+          log.debug("Upload for {} has hit Google Cloud Storage multipart-compose limits; " +
+              "consider increasing '{}' beyond current value of {}", destination, CHUNK_SIZE_PROPERTY, getChunkSize());
+          // we've hit compose request limit read the rest of the stream
+          composeLimitHit.incrementAndGet();
+          chunk = IOUtils.toByteArray(current);
+        }
+        if (chunk == EMPTY && partNumber > 1) {
+          break;
+        }
+        else {
+          final int chunkIndex = partNumber;
+          chunkFutures.add(executorService.submit(() -> {
+            log.debug("Uploading chunk {} for {} of {} bytes", chunkIndex, destination, chunk.length);
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                bucket, toChunkName(destination, chunkIndex)).build();
+            return storage.create(blobInfo, chunk);
+          }));
+        }
+      }
+
+      final int numberOfChunks = chunkFutures.size();
+      CountDownLatch block = new CountDownLatch(1);
+      Futures.whenAllComplete(chunkFutures).run(() -> block.countDown() , MoreExecutors.directExecutor());
+      // create list of all the chunks
+      List<String> chunkBlobs = IntStream.rangeClosed(1, numberOfChunks)
+          .mapToObj(i -> toChunkName(destination, i))
+          .collect(Collectors.toList());
+
+      // wait for all the futures to complete
+      log.debug("waiting for {} chunks to complete", chunkFutures.size());
+      block.await();
+      log.debug("chunk uploads completed, sending compose request");
+      // finalize with compose request to coalesce the chunks
+      Blob finalBlob = storage.compose(ComposeRequest.of(bucket, chunkBlobs, destination));
+      log.debug("Multipart upload of {} complete", destination);
+
+      deferredCleanup(storage, bucket, chunkBlobs);
+
+      return finalBlob;
+    }
+    catch(Exception e) {
+      deferredCleanup(storage, bucket, parts);
+      throw new BlobStoreException("Error uploading blob", e, null);
+    }
+  }
+
+  private void deferredCleanup(final Storage storage, final String bucket, final List<String> parts) {
+    executorService.submit(() -> {
+      parts.stream().forEach(part -> storage.delete(bucket, part));
+    });
+  }
+
+  private String toChunkName(String destination, int chunkNumber) {
+    return destination + CHUNK_NAME_PART + chunkNumber;
+  }
+
+  /**
+   * Read a chunk of the stream up to {@link #getChunkSize()} in length.
+   *
+   * @param input
+   * @return the read data as a byte array
+   * @throws IOException
+   */
+  private byte[] readChunk(final InputStream input) throws IOException {
+    byte[] buffer = new byte[chunkSize];
+    int offset = 0;
+    int remain = chunkSize;
+    int bytesRead = 0;
+
+    while (remain > 0 && bytesRead >= 0) {
+      bytesRead = input.read(buffer, offset, remain);
+      if (bytesRead > 0) {
+        offset += bytesRead;
+        remain -= bytesRead;
+      }
+    }
+    if (offset > 0) {
+      return Arrays.copyOfRange(buffer, 0, offset);
+    }
+    else {
+      return EMPTY;
+    }
+  }
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
@@ -253,25 +253,4 @@ public class MultipartUploader
       return EMPTY;
     }
   }
-
-  private InputStream streamChunk(final InputStream input) throws IOException {
-    byte[] buffer = new byte[chunkSize];
-    int offset = 0;
-    int remain = chunkSize;
-    int bytesRead = 0;
-
-    while (remain > 0 && bytesRead >= 0) {
-      bytesRead = input.read(buffer, offset, remain);
-      if (bytesRead > 0) {
-        offset += bytesRead;
-        remain -= bytesRead;
-      }
-    }
-    if (offset > 0) {
-      return new ByteArrayInputStream(buffer, 0, offset);
-    }
-    else {
-      return EMPTY_STREAM;
-    }
-  }
 }

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -134,6 +134,7 @@ class GoogleCloudBlobStoreTest
       storage.get('mybucket') >> bucket
       blobStore.init(config)
       blobStore.doStart()
+      storage.create(_, _) >> mockGoogleObject(tempFileBytes)
 
     when: 'call create'
       Blob blob = blobStore.create(new ByteArrayInputStream('hello world'.bytes), blobHeaders)

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -51,6 +51,8 @@ class GoogleCloudBlobStoreTest
 
   Datastore datastore = Mock()
 
+  MultipartUploader uploader = new MultipartUploader(1024)
+
   KeyFactory keyFactory = new KeyFactory("testing")
 
   def blobHeaders = [
@@ -58,7 +60,8 @@ class GoogleCloudBlobStoreTest
       (BlobStore.CREATED_BY_HEADER): 'admin'
   ]
   GoogleCloudBlobStore blobStore = new GoogleCloudBlobStore(
-      storageFactory, blobIdLocationResolver, metricsStore, datastoreFactory, new DryRunPrefix("TEST "))
+      storageFactory, blobIdLocationResolver, metricsStore, datastoreFactory, new DryRunPrefix("TEST "),
+      uploader)
 
   def config = new BlobStoreConfiguration()
 

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploaderIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploaderIT.groovy
@@ -1,0 +1,135 @@
+package org.sonatype.nexus.blobstore.gcloud.internal
+
+import java.util.stream.StreamSupport
+
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
+
+import com.google.cloud.storage.Blob
+import com.google.cloud.storage.Blob.BlobSourceOption
+import com.google.cloud.storage.BucketInfo
+import com.google.cloud.storage.Storage
+import groovy.util.logging.Slf4j
+import org.apache.commons.io.input.BoundedInputStream
+import spock.lang.Specification
+
+@Slf4j
+class MultipartUploaderIT
+    extends Specification
+{
+
+  static final BlobStoreConfiguration config = new BlobStoreConfiguration()
+
+  static final GoogleCloudStorageFactory storageFactory = new GoogleCloudStorageFactory()
+
+  static String bucketName = "integration-test-${UUID.randomUUID().toString()}"
+
+  static Storage storage
+
+  def setupSpec() {
+    config.attributes = [
+        'google cloud storage': [
+            bucket: bucketName,
+            credential_file: this.getClass().getResource('/gce-credentials.json').getFile()
+        ]
+    ]
+
+    log.info("Integration test using bucket ${bucketName}")
+    storage = storageFactory.create(config)
+    storage.create(BucketInfo.of(bucketName))
+  }
+
+  def cleanupSpec() {
+    //Storage storage = new GoogleCloudStorageFactory().create(config)
+    log.debug("Tests complete, deleting files from ${bucketName}")
+    // must delete all the files within the bucket before we can delete the bucket
+    Iterator<com.google.cloud.storage.Blob> list = storage.list(bucketName,
+        Storage.BlobListOption.prefix("")).iterateAll()
+        .iterator()
+
+    Iterable<com.google.cloud.storage.Blob> iterable = { _ -> list }
+    StreamSupport.stream(iterable.spliterator(), true)
+        .forEach({ b -> b.delete(BlobSourceOption.generationMatch()) })
+    storage.delete(bucketName)
+    log.info("Integration test complete, bucket ${bucketName} deleted")
+  }
+
+  def "control experiment"() {
+    given:
+      long expectedSize = (1048576 * 3) + 2
+      MultipartUploader uploader = new MultipartUploader(1048576)
+      byte[] data = new byte[expectedSize]
+      new Random().nextBytes(data)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/test', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == expectedSize
+  }
+
+  def "zero byte file"() {
+    given:
+      long expectedSize = 0
+      MultipartUploader uploader = new MultipartUploader(1024)
+      byte[] data = new byte[expectedSize]
+      new Random().nextBytes(data)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/zero_byte', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == expectedSize
+  }
+
+  def "hit compose limit slightly and still successful"() {
+    given:
+      long expectedSize = (1024 * MultipartUploader.COMPOSE_REQUEST_LIMIT) + 10
+      MultipartUploader uploader = new MultipartUploader(1024)
+      byte[] data = new byte[expectedSize]
+      new Random().nextBytes(data)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName,
+          'vol-01/chap-01/composeLimitTest/small_miss', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == expectedSize
+      uploader.numberOfTimesComposeLimitHit == 1L
+  }
+
+  def "hit compose limit poorly tuned, still successful" () {
+    given:
+      long expectedSize = 1048576
+      MultipartUploader uploader = new MultipartUploader(1024)
+      byte[] data = new byte[expectedSize]
+      new Random().nextBytes(data)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName,
+          'vol-01/chap-01/composeLimitTest/poor_tuning', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == expectedSize
+      uploader.numberOfTimesComposeLimitHit == 1L
+  }
+
+  def "upload 100 MB"() {
+    given:
+      long expectedSize = 1024 * 1024 * 100
+      BoundedInputStream inputStream = new BoundedInputStream(new InputStream() {
+        private Random random = new Random()
+        @Override
+        int read() throws IOException {
+          return random.nextInt()
+        }
+      }, expectedSize)
+      // default value of 5 MB per chunk
+      MultipartUploader uploader = new MultipartUploader(1024 * 1024 * 5)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName,
+          'vol-01/chap-02/large/one_hundred_MB', inputStream)
+    then:
+      blob.size == expectedSize
+  }
+}

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploaderIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploaderIT.groovy
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.blobstore.gcloud.internal
 
 import java.util.stream.StreamSupport
@@ -53,7 +65,7 @@ class MultipartUploaderIT
     log.info("Integration test complete, bucket ${bucketName} deleted")
   }
 
-  def "control experiment"() {
+  def "simple multipart"() {
     given:
       long expectedSize = (1048576 * 3) + 2
       MultipartUploader uploader = new MultipartUploader(1048576)
@@ -61,7 +73,37 @@ class MultipartUploaderIT
       new Random().nextBytes(data)
 
     when:
-      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/test', new ByteArrayInputStream(data))
+      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/multi_part', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == expectedSize
+  }
+
+  def "confirm parts composed in order"() {
+    given:
+      // 5 each of abcdefg
+      final String content =  "aaaaabbbbbcccccdddddeeeeefffffggggg"
+      byte[] data = content.bytes
+      MultipartUploader uploader = new MultipartUploader(5)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/in_order', new ByteArrayInputStream(data))
+
+    then:
+      blob.size == data.length
+      Blob readback = storage.get(blob.blobId)
+      readback.getContent() == content.bytes
+  }
+
+  def "single part"() {
+    given:
+      long expectedSize = 1048575
+      MultipartUploader uploader = new MultipartUploader(1048576)
+      byte[] data = new byte[expectedSize]
+      new Random().nextBytes(data)
+
+    when:
+      Blob blob = uploader.upload(storage, bucketName, 'vol-01/chap-01/control/single_part', new ByteArrayInputStream(data))
 
     then:
       blob.size == expectedSize


### PR DESCRIPTION
This pull request captures an experiment with using parallel multipart upload and Google Cloud Storage [Composite Objects](https://cloud.google.com/storage/docs/composite-objects).

This change set includes a new client, `MultipartUploader` that encapsulates the splitting of an incoming stream, uploading them in parallel, and finally issuing a compose request to combine them at close.

Some observations:
* The Java client prefers that you pass a `byte[]` rather than an `InputStream`, and it does so for an interesting reason. The [`byte[]` variant](https://googleapis.github.io/google-cloud-java/google-cloud-clients/apidocs/com/google/cloud/storage/Storage.html#create-com.google.cloud.storage.BlobInfo-byte:A-com.google.cloud.storage.Storage.BlobTargetOption...-) automatically can retry on some failure cases and is recommended, [the InputStream variant](https://googleapis.github.io/google-cloud-java/google-cloud-clients/apidocs/com/google/cloud/storage/Storage.html#create-com.google.cloud.storage.BlobInfo-java.io.InputStream-com.google.cloud.storage.Storage.BlobWriteOption...-) does not, since the stream can only be used once.
* The compose request operation has a hard limit of 32 chunks. This can be a little tricky to accommodate. I chose a configuration parameter for `chunkSize` to allow deployers to customize based on workloads (some repository formats have larger assets than others). If the chunkSize is too low, you could easily run into a circumstance with 31 chunks of a small size and 1 giant chunk that we have to wait for.

Does it perform better or worse than single thread? I setup a single NXRM instance with the plugin on a n1-highmem-4 GCP instance, and used another GCP instance in the same VPC to generate a diverse workload. I ran the same workload with the current master build (using single threaded uploads).

The results? Higher CPU utilization and lower overall network I/O:

<img width="1092" alt="gcp-mpu-experiment" src="https://user-images.githubusercontent.com/1041730/51751781-617a9300-207b-11e9-8569-f4f802104a37.png">

I don't believe this to be suitable approach for NXRM blobstores at this time.

This was a valuable experiment. I will be porting the increase to the connections per route configuration and some of the integration tests to the final product. I do not intend to merge this change set at this time; opening this PR just to capture the results. Relates to #1.

