### PR TITLE
Update to support NXRM 3.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+
+jdk:
+  - openjdk8

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Nexus Repository Google Cloud Storage Blobstore
 [![Build Status](https://travis-ci.org/sonatype-nexus-community/nexus-blobstore-google-cloud.svg?branch=master)](https://travis-ci.org/sonatype-nexus-community/nexus-blobstore-google-cloud) [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This project adds [Google Cloud Object Storage](https://cloud.google.com/storage/) backed blobstores to Sonatype Nexus 
-Repository 3.14 and later.  It allows Nexus Repository to store the components and assets in Google Cloud instead of a
+Repository 3.15 and later.  It allows Nexus Repository to store the components and assets in Google Cloud instead of a
 local filesystem.
 
 Contribution Guidelines

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.14.0-04</version>
+    <version>3.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.sonatype.nexus</groupId>
+      <artifactId>nexus-repository</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.15.0-SNAPSHOT</version>
+    <version>3.15.2-01</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud</artifactId>

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleAttributesLocation.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleAttributesLocation.java
@@ -9,16 +9,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class GoogleAttributesLocation
     implements AttributesLocation
 {
-  private String key;
+  private final String key;
+  private final String fullPath;
 
   public GoogleAttributesLocation(final BlobInfo blobInfo) {
     checkNotNull(blobInfo);
     this.key = checkNotNull(blobInfo.getName());
+    this.fullPath = key.substring(key.lastIndexOf('/') + 1);
   }
 
   @Override
   public String getFileName() {
-    return key.substring(key.lastIndexOf('/') + 1);
+    return this.fullPath;
   }
 
   @Override

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleAttributesLocation.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleAttributesLocation.java
@@ -1,0 +1,29 @@
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import org.sonatype.nexus.blobstore.AttributesLocation;
+
+import com.google.cloud.storage.BlobInfo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GoogleAttributesLocation
+    implements AttributesLocation
+{
+  private String key;
+
+  public GoogleAttributesLocation(final BlobInfo blobInfo) {
+    checkNotNull(blobInfo);
+    this.key = checkNotNull(blobInfo.getName());
+  }
+
+  @Override
+  public String getFileName() {
+    return key.substring(key.lastIndexOf('/') + 1);
+  }
+
+  @Override
+  public String getFullPath() {
+    return key;
+  }
+
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobAttributes.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobAttributes.java
@@ -13,79 +13,26 @@
 package org.sonatype.nexus.blobstore.gcloud.internal;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
 
-import org.sonatype.nexus.blobstore.api.BlobAttributes;
+import org.sonatype.nexus.blobstore.BlobAttributesSupport;
 import org.sonatype.nexus.blobstore.api.BlobMetrics;
 
 import com.google.cloud.storage.Bucket;
-import org.joda.time.DateTime;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.CONTENT_SIZE_ATTRIBUTE;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.CREATION_TIME_ATTRIBUTE;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.DELETED_ATTRIBUTE;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.DELETED_REASON_ATTRIBUTE;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.HEADER_PREFIX;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.SHA1_HASH_ATTRIBUTE;
 
 public class GoogleCloudBlobAttributes
-    implements BlobAttributes
+    extends BlobAttributesSupport<GoogleCloudPropertiesFile>
 {
-  private Map<String, String> headers;
-
-  private BlobMetrics metrics;
-
-  private boolean deleted = false;
-
-  private String deletedReason;
-
-  private final GoogleCloudPropertiesFile propertiesFile;
 
   public GoogleCloudBlobAttributes(final Bucket bucket, final String key) {
-    checkNotNull(key);
-    checkNotNull(bucket);
-    this.propertiesFile = new GoogleCloudPropertiesFile(bucket, key);
+    super(new GoogleCloudPropertiesFile(bucket, key), null, null);
   }
 
   public GoogleCloudBlobAttributes(final Bucket bucket, final String key, final Map<String, String> headers,
                           final BlobMetrics metrics) {
-    this(bucket, key);
-    this.headers = checkNotNull(headers);
-    this.metrics = checkNotNull(metrics);
-  }
-
-  @Override
-  public Map<String, String> getHeaders() {
-    return headers;
-  }
-
-  @Override
-  public BlobMetrics getMetrics() {
-    return metrics;
-  }
-
-  @Override
-  public boolean isDeleted() {
-    return deleted;
-  }
-
-  @Override
-  public void setDeleted(final boolean deleted) {
-    this.deleted = deleted;
-  }
-
-  @Override
-  public void setDeletedReason(final String deletedReason) {
-    this.deletedReason = deletedReason;
-  }
-
-  @Override
-  public String getDeletedReason() {
-    return deletedReason != null ? deletedReason : "No reason supplied";
+    super(new GoogleCloudPropertiesFile(bucket, key), checkNotNull(headers), checkNotNull(metrics));
   }
 
   public boolean load() throws IOException {
@@ -100,56 +47,5 @@ public class GoogleCloudBlobAttributes
   public void store() throws IOException {
     writeTo(propertiesFile);
     propertiesFile.store();
-  }
-
-  @Override
-  public Properties getProperties() {
-    return new Properties(propertiesFile);
-  }
-
-  @Override
-  public void updateFrom(final BlobAttributes blobAttributes) {
-    headers = blobAttributes.getHeaders();
-    metrics = blobAttributes.getMetrics();
-    deleted = blobAttributes.isDeleted();
-    deletedReason = blobAttributes.getDeletedReason();
-  }
-
-  private void readFrom(Properties properties) {
-    headers = new HashMap<>();
-    for (Entry<Object, Object> property : properties.entrySet()) {
-      String key = (String) property.getKey();
-      if (key.startsWith(HEADER_PREFIX)) {
-        headers.put(key.substring(HEADER_PREFIX.length()), String.valueOf(property.getValue()));
-      }
-    }
-
-    metrics = new BlobMetrics(
-        new DateTime(Long.parseLong(properties.getProperty(CREATION_TIME_ATTRIBUTE))),
-        properties.getProperty(SHA1_HASH_ATTRIBUTE),
-        Long.parseLong(properties.getProperty(CONTENT_SIZE_ATTRIBUTE)));
-
-    deleted = properties.containsKey(DELETED_ATTRIBUTE);
-    deletedReason = properties.getProperty(DELETED_REASON_ATTRIBUTE);
-  }
-
-  private Properties writeTo(final Properties properties) {
-    for (Entry<String, String> header : getHeaders().entrySet()) {
-      properties.put(HEADER_PREFIX + header.getKey(), header.getValue());
-    }
-    BlobMetrics blobMetrics = getMetrics();
-    properties.setProperty(SHA1_HASH_ATTRIBUTE, blobMetrics.getSha1Hash());
-    properties.setProperty(CONTENT_SIZE_ATTRIBUTE, Long.toString(blobMetrics.getContentSize()));
-    properties.setProperty(CREATION_TIME_ATTRIBUTE, Long.toString(blobMetrics.getCreationTime().getMillis()));
-
-    if (deleted) {
-      properties.put(DELETED_ATTRIBUTE, Boolean.toString(deleted));
-      properties.put(DELETED_REASON_ATTRIBUTE, getDeletedReason());
-    }
-    else {
-      properties.remove(DELETED_ATTRIBUTE);
-      properties.remove(DELETED_REASON_ATTRIBUTE);
-    }
-    return properties;
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -146,6 +146,7 @@ public class GoogleCloudBlobStore
     liveBlobs = CacheBuilder.newBuilder().weakValues().build(from(GoogleCloudStorageBlob::new));
 
     metricsStore.setBucket(bucket);
+    metricsStore.setBlobStore(this);
     metricsStore.start();
   }
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.sonatype.nexus.blobstore.AttributesLocation;
 import org.sonatype.nexus.blobstore.BlobIdLocationResolver;
 import org.sonatype.nexus.blobstore.BlobStoreSupport;
 import org.sonatype.nexus.blobstore.BlobSupport;
@@ -69,7 +70,6 @@ import static com.google.common.cache.CacheLoader.from;
 import static com.google.common.collect.Streams.stream;
 import static java.lang.String.format;
 import static org.sonatype.nexus.blobstore.DirectPathLocationStrategy.DIRECT_PATH_ROOT;
-import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.HEADER_PREFIX;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.FAILED;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.NEW;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
@@ -80,7 +80,7 @@ import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.St
  */
 @Named(GoogleCloudBlobStore.TYPE)
 public class GoogleCloudBlobStore
-    extends BlobStoreSupport
+    extends BlobStoreSupport<GoogleAttributesLocation>
 {
   public static final String TYPE = "Google Cloud Storage";
 
@@ -92,11 +92,7 @@ public class GoogleCloudBlobStore
 
   public static final String BLOB_CONTENT_SUFFIX = ".bytes";
 
-  public static final String BLOB_ATTRIBUTE_SUFFIX = ".properties";
-
   static final String CONTENT_PREFIX = "content";
-
-  public static final String TEMPORARY_BLOB_ID_PREFIX = "tmp$";
 
   public static final String METADATA_FILENAME = "metadata.properties";
 
@@ -125,7 +121,8 @@ public class GoogleCloudBlobStore
                               final BlobIdLocationResolver blobIdLocationResolver,
                               final GoogleCloudBlobStoreMetricsStore storeMetrics,
                               final GoogleCloudDatastoreFactory datastoreFactory,
-                              final DryRunPrefix dryRunPrefix) {
+                              final DryRunPrefix dryRunPrefix)
+  {
     super(blobIdLocationResolver, dryRunPrefix);
     this.storageFactory = checkNotNull(storageFactory);
     this.storeMetrics = storeMetrics;
@@ -275,10 +272,7 @@ public class GoogleCloudBlobStore
   }
 
   @Override
-  @Guarded(by = STARTED)
-  public boolean deleteHard(final BlobId blobId) {
-    checkNotNull(blobId);
-
+  protected boolean doDeleteHard(final BlobId blobId) {
     try {
       log.debug("Hard deleting blob {}", blobId);
 
@@ -317,8 +311,7 @@ public class GoogleCloudBlobStore
 
   @Override
   @Guarded(by = STARTED)
-  public void compact(@Nullable final BlobStoreUsageChecker blobStoreUsageChecker) {
-
+  public void doCompact(@Nullable final BlobStoreUsageChecker blobStoreUsageChecker) {
     log.info("Begin deleted blobs processing");
     ProgressLogIntervalHelper progressLogger = new ProgressLogIntervalHelper(log, 60);
     final AtomicInteger counter = new AtomicInteger(0);
@@ -337,6 +330,14 @@ public class GoogleCloudBlobStore
   @Override
   public BlobStoreConfiguration getBlobStoreConfiguration() {
     return this.blobStoreConfiguration;
+  }
+
+  @Override
+  protected BlobAttributes getBlobAttributes(final GoogleAttributesLocation attributesFilePath) throws IOException {
+    GoogleCloudBlobAttributes googleCloudBlobAttributes = new GoogleCloudBlobAttributes(bucket,
+        attributesFilePath.getFileName());
+    googleCloudBlobAttributes.load();
+    return googleCloudBlobAttributes;
   }
 
   @Override
@@ -371,51 +372,26 @@ public class GoogleCloudBlobStore
   @Override
   @Guarded(by = STARTED)
   public Stream<BlobId> getBlobIdStream() {
-    return blobStream(CONTENT_PREFIX)
-        .filter(blob -> blob.getName().endsWith(BLOB_ATTRIBUTE_SUFFIX) &&
-            !basename(blob).startsWith(TEMPORARY_BLOB_ID_PREFIX))
-        .map(BlobInfo::getBlobId)
-        .map(blobId -> new BlobId(blobId.toString()));
+    return getBlobIdStream(CONTENT_PREFIX);
   }
 
   @Override
   @Guarded(by = STARTED)
   public Stream<BlobId> getDirectPathBlobIdStream(final String prefix) {
     String subpath = format("%s/%s/%s", CONTENT_PREFIX, DIRECT_PATH_ROOT, prefix);
-    return blobStream(subpath)
-        .filter(blob -> blob.getName().endsWith(BLOB_ATTRIBUTE_SUFFIX) &&
-            !basename(blob).startsWith(TEMPORARY_BLOB_ID_PREFIX))
-        .map(blob -> cloudBlobIdToDirectPathBlobId(blob.getBlobId()));
+    return getBlobIdStream(subpath);
   }
 
-  /**
-   * Used by {@link #getDirectPathBlobIdStream(String)} to convert an Google cloud BlobId to a Nexus {@link BlobId}.
-   *
-   * @see BlobIdLocationResolver
-   */
-  private BlobId cloudBlobIdToDirectPathBlobId(final com.google.cloud.storage.BlobId blobId) {
-    final String blobName = blobId.getName();
-    checkArgument(blobName.startsWith(CONTENT_PREFIX + "/" + DIRECT_PATH_ROOT + "/"),
-        "Not direct path blob path: %s", blobName);
-    checkArgument(blobName.endsWith(BLOB_ATTRIBUTE_SUFFIX), "Not blob attribute path: %s", blobName);
-    String subpath = blobName.replace(format("%s/%s/", CONTENT_PREFIX, DIRECT_PATH_ROOT), "");
-    String name = subpath.substring(0, subpath.length() - BLOB_ATTRIBUTE_SUFFIX.length());
-
-    Map<String, String> headers = ImmutableMap.of(
-        BLOB_NAME_HEADER, name,
-        DIRECT_PATH_BLOB_HEADER, "true"
-    );
-    return blobIdLocationResolver.fromHeaders(headers);
+  private Stream<BlobId> getBlobIdStream(final String subpath) {
+    return blobStream(subpath)
+        .filter(blob -> blob.getName().endsWith(BLOB_ATTRIBUTE_SUFFIX))
+        .map(GoogleAttributesLocation::new)
+        .map(this::getBlobIdFromAttributeFilePath)
+        .map(BlobId::new);
   }
 
   Stream<BlobInfo> blobStream(final String path) {
-    return stream(bucket.list(BlobListOption.prefix(path)).iterateAll())
-        .map(c -> c);
-  }
-
-  String basename(final BlobInfo blob) {
-    String name = blob.getName();
-    return name.substring(name.lastIndexOf('/') + 1);
+    return stream(bucket.list(BlobListOption.prefix(path)).iterateAll()).map(c -> c);
   }
 
   /**
@@ -443,7 +419,8 @@ public class GoogleCloudBlobStore
       try {
         existing.updateFrom(blobAttributes);
         existing.store();
-      } catch (IOException e) {
+      }
+      catch (IOException e) {
         log.error("Unable to set GoogleCloudBlobAttributes for blob id: {}", blobId, e);
       }
     }
@@ -461,42 +438,8 @@ public class GoogleCloudBlobStore
   }
 
   @Override
-  @Guarded(by = STARTED)
-  public boolean undelete(@Nullable final BlobStoreUsageChecker blobStoreUsageChecker,
-                          final BlobId blobId,
-                          final BlobAttributes attributes,
-                          final boolean isDryRun)
-  {
-    checkNotNull(attributes);
-    String logPrefix = isDryRun ? dryRunPrefix.get() : "";
-    Optional<String> blobName = Optional.of(attributes)
-        .map(BlobAttributes::getProperties)
-        .map(p -> p.getProperty(HEADER_PREFIX + BLOB_NAME_HEADER));
-    if (!blobName.isPresent()) {
-      log.error("Property not present: {}, for blob id: {}, at path: {}", HEADER_PREFIX + BLOB_NAME_HEADER,
-          blobId, attributePath(blobId));
-      return false;
-    }
-    if (attributes.isDeleted() && blobStoreUsageChecker != null &&
-        blobStoreUsageChecker.test(this, blobId, blobName.get())) {
-      String deletedReason = attributes.getDeletedReason();
-      if (!isDryRun) {
-        attributes.setDeleted(false);
-        attributes.setDeletedReason(null);
-        try {
-          attributes.store();
-        }
-        catch (IOException e) {
-          log.error("Error while un-deleting blob id: {}, deleted reason: {}, blob store: {}, blob name: {}",
-              blobId, deletedReason, blobStoreConfiguration.getName(), blobName.get(), e);
-        }
-      }
-      log.warn(
-          "{}Soft-deleted blob still in use, un-deleting blob id: {}, deleted reason: {}, blob store: {}, blob name: {}",
-          logPrefix, blobId, deletedReason, blobStoreConfiguration.getName(), blobName.get());
-      return true;
-    }
-    return false;
+  public boolean isStorageAvailable() {
+    return true;
   }
 
   @Override
@@ -511,7 +454,8 @@ public class GoogleCloudBlobStore
       List<Boolean> results = storage.testIamPermissions(getConfiguredBucketName(),
           Arrays.asList("storage.objects.create", "storage.objects.delete"));
       return !results.contains(false);
-    } catch (StorageException e) {
+    }
+    catch (StorageException e) {
       throw new BlobStoreException("failed to retrive User ACL for " + getConfiguredBucketName(), e, null);
     }
   }
@@ -564,7 +508,8 @@ public class GoogleCloudBlobStore
   private void deleteNonExplosively(final String contentPath) {
     try {
       storage.delete(getConfiguredBucketName(), contentPath);
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       log.warn("caught exception attempting to delete during cleanup", e);
     }
   }
@@ -605,7 +550,9 @@ public class GoogleCloudBlobStore
     }
   }
 
-  class GoogleCloudStorageBlob extends BlobSupport {
+  class GoogleCloudStorageBlob
+      extends BlobSupport
+  {
     GoogleCloudStorageBlob(BlobId blobId) {
       super(blobId);
     }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreMetricsStore.java
@@ -13,154 +13,62 @@
 package org.sonatype.nexus.blobstore.gcloud.internal;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.sonatype.nexus.blobstore.AccumulatingBlobStoreMetrics;
+import org.sonatype.nexus.blobstore.BlobStoreMetricsStoreSupport;
 import org.sonatype.nexus.blobstore.PeriodicJobService;
-import org.sonatype.nexus.blobstore.PeriodicJobService.PeriodicJob;
-import org.sonatype.nexus.blobstore.api.BlobStoreMetrics;
+import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaService;
 import org.sonatype.nexus.common.node.NodeAccess;
-import org.sonatype.nexus.common.stateguard.Guarded;
-import org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Long.parseLong;
-import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
+import static com.google.common.collect.Streams.stream;
 
 @Named
 public class GoogleCloudBlobStoreMetricsStore
-    extends StateGuardLifecycleSupport
+    extends BlobStoreMetricsStoreSupport<GoogleCloudPropertiesFile>
 {
-  private static final String METRICS_SUFFIX = "-metrics";
-
-  private static final String METRICS_EXTENSION = ".properties";
-
-  private static final String TOTAL_SIZE_PROP_NAME = "totalSize";
-
-  private static final String BLOB_COUNT_PROP_NAME = "blobCount";
-
-  private static final int METRICS_FLUSH_PERIOD_SECONDS = 2;
-
-  private final PeriodicJobService jobService;
-
-  private AtomicLong blobCount;
-
-  private final NodeAccess nodeAccess;
-
-  private AtomicLong totalSize;
-
-  private AtomicBoolean dirty;
-
-  private PeriodicJob metricsWritingJob;
-
-  private GoogleCloudPropertiesFile propertiesFile;
-
   private Bucket bucket;
 
   @Inject
-  public GoogleCloudBlobStoreMetricsStore(final PeriodicJobService jobService, final NodeAccess nodeAccess) {
-    this.jobService = checkNotNull(jobService);
-    this.nodeAccess = checkNotNull(nodeAccess);
-  }
-
-  @Override
-  protected void doStart() throws Exception {
-    blobCount = new AtomicLong();
-    totalSize = new AtomicLong();
-    dirty = new AtomicBoolean();
-
-    propertiesFile = new GoogleCloudPropertiesFile(bucket, nodeAccess.getId() + METRICS_SUFFIX + METRICS_EXTENSION);
-    if (propertiesFile.exists()) {
-      log.info("Loading blob store metrics file {}", propertiesFile);
-      propertiesFile.load();
-      readProperties();
-    }
-    else {
-      log.info("Blob store metrics file {} not found - initializing at zero.", propertiesFile);
-      updateProperties();
-      propertiesFile.store();
-    }
-
-    jobService.startUsing();
-    metricsWritingJob = jobService.schedule(() -> {
-      try {
-        if (dirty.compareAndSet(true, false)) {
-          updateProperties();
-          log.trace("Writing blob store metrics to {}", propertiesFile);
-          propertiesFile.store();
-        }
-      }
-      catch (Exception e) {
-        // Don't propagate, as this stops subsequent executions
-        log.error("Cannot write blob store metrics", e);
-      }
-    }, METRICS_FLUSH_PERIOD_SECONDS);
+  public GoogleCloudBlobStoreMetricsStore(final PeriodicJobService jobService,
+                                          final NodeAccess nodeAccess,
+                                          final BlobStoreQuotaService quotaService,
+                                          @Named("${nexus.blobstore.quota.warnIntervalSeconds:-60}")
+                                          final int quotaCheckInterval)
+  {
+    super(nodeAccess, jobService, quotaService, quotaCheckInterval);
   }
 
   @Override
   protected void doStop() throws Exception {
-    metricsWritingJob.cancel();
-    metricsWritingJob = null;
-    jobService.stopUsing();
+    super.doStop();
 
-    blobCount = null;
-    totalSize = null;
-    dirty = null;
+    bucket = null;
+  }
 
-    propertiesFile = null;
+  @Override
+  protected GoogleCloudPropertiesFile getProperties() {
+    return new GoogleCloudPropertiesFile(bucket, nodeAccess.getId() + "-" + METRICS_FILENAME);
+  }
+
+  @Override
+  protected AccumulatingBlobStoreMetrics getAccumulatingBlobStoreMetrics() {
+    return new AccumulatingBlobStoreMetrics(0, 0, ImmutableMap.of("gcp", Long.MAX_VALUE), true);
   }
 
   public void setBucket(final Bucket bucket) {
     checkState(this.bucket == null, "Do not initialize twice");
     checkNotNull(bucket);
     this.bucket = bucket;
-  }
-
-  @Guarded(by = STARTED)
-  public BlobStoreMetrics getMetrics() {
-    Stream<GoogleCloudPropertiesFile> blobStoreMetricsFiles = backingFiles();
-    return getCombinedMetrics(blobStoreMetricsFiles);
-  }
-
-  private BlobStoreMetrics getCombinedMetrics(final Stream<GoogleCloudPropertiesFile> blobStoreMetricsFiles) {
-    AccumulatingBlobStoreMetrics blobStoreMetrics = new AccumulatingBlobStoreMetrics(0, 0,
-        ImmutableMap.of("gcp", Long.MAX_VALUE), true);
-
-    blobStoreMetricsFiles.forEach(metricsFile -> {
-      try {
-        metricsFile.load();
-        blobStoreMetrics.addBlobCount(parseLong(metricsFile.getProperty(BLOB_COUNT_PROP_NAME, "0")));
-        blobStoreMetrics.addTotalSize(parseLong(metricsFile.getProperty(TOTAL_SIZE_PROP_NAME, "0")));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
-    return blobStoreMetrics;
-  }
-
-  @Guarded(by = STARTED)
-  public void recordAddition(final long size) {
-    blobCount.incrementAndGet();
-    totalSize.addAndGet(size);
-    dirty.set(true);
-  }
-
-  @Guarded(by = STARTED)
-  public void recordDeletion(final long size) {
-    blobCount.decrementAndGet();
-    totalSize.addAndGet(-size);
-    dirty.set(true);
   }
 
   public void remove() {
@@ -174,30 +82,13 @@ public class GoogleCloudBlobStoreMetricsStore
     });
   }
 
-  private Stream<GoogleCloudPropertiesFile> backingFiles() {
+  protected Stream<GoogleCloudPropertiesFile> backingFiles() {
     if (bucket == null) {
       return Stream.empty();
     } else {
-      return Streams.stream(bucket.list(BlobListOption.prefix(nodeAccess.getId())).iterateAll())
-          .filter(b -> b.getName().endsWith(METRICS_EXTENSION))
+      return stream(bucket.list(BlobListOption.prefix(nodeAccess.getId())).iterateAll())
+          .filter(b -> b.getName().endsWith(METRICS_FILENAME))
           .map(blob -> new GoogleCloudPropertiesFile(bucket, blob.getName()));
-    }
-  }
-
-  private void updateProperties() {
-    propertiesFile.setProperty(TOTAL_SIZE_PROP_NAME, totalSize.toString());
-    propertiesFile.setProperty(BLOB_COUNT_PROP_NAME, blobCount.toString());
-  }
-
-  private void readProperties() {
-    String size = propertiesFile.getProperty(TOTAL_SIZE_PROP_NAME);
-    if (size != null) {
-      totalSize.set(parseLong(size));
-    }
-
-    String count = propertiesFile.getProperty(BLOB_COUNT_PROP_NAME);
-    if (count != null) {
-      blobCount.set(parseLong(count));
     }
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudPropertiesFile.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudPropertiesFile.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.util.Properties;
 
+import org.sonatype.nexus.common.property.ImplicitSourcePropertiesFile;
+
 import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
@@ -31,7 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * {@link Properties} representation stored in Google Cloud Storage.
  */
 public class GoogleCloudPropertiesFile
-    extends Properties
+    extends ImplicitSourcePropertiesFile
 {
   private static final Logger log = LoggerFactory.getLogger(GoogleCloudPropertiesFile.class);
 


### PR DESCRIPTION
This change set updates to link against NXRM 3.15.2-01.

The new version of NXRM provides a number of new support classes to handle boiler plate for Blobstore implementations (see BlobStoreSupport, BlobStoreMetricsStoreSupport, BlobAttributesSupport, AttributesLocation).

Other notable changes:
* We have some new clarity on the contract Blobstore#getBlobIdStream. In previous versions, the Stream returned by this method in this plugin did not include temporary blobs. In this version, temporary BlobIds are included.
* A new integration test has been added (originally developed in #22).
* The travis CI build has been updated to use openjdk8.

* Fixes #24
