### PR TITLE
Updates to docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: java
 
+services:
+  - docker
+
+before_install:
+  - docker build -t sonatype/test_build_nexues_blobstore_google_cloud .
+
 jdk:
   - openjdk8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM maven as nexus-blobstore-google-cloud
+FROM maven:3.6-jdk-8-alpine as nexus-blobstore-google-cloud
 WORKDIR /build
-RUN git clone https://github.com/sonatype-nexus-community/nexus-blobstore-google-cloud.git .
-RUN mvn clean install
+COPY . /build/.
+RUN mvn clean package
 
 FROM sonatype/nexus3:3.13.0
 ADD install-plugin.sh /opt/plugins/nexus-blobstore-google-cloud/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . /build/.
 RUN mvn clean package
 
-FROM sonatype/nexus3:3.13.0
+FROM sonatype/nexus3:3.15.2
 ADD install-plugin.sh /opt/plugins/nexus-blobstore-google-cloud/
 COPY --from=nexus-blobstore-google-cloud /build/target/ /opt/plugins/nexus-blobstore-google-cloud/target/
 COPY --from=nexus-blobstore-google-cloud /build/pom.xml /opt/plugins/nexus-blobstore-google-cloud/


### PR DESCRIPTION
This pull request makes the following changes:
* Builds docker image based off of working directory with pinned version of maven using jdk-8
* Adds step to travis to build image to confirm it builds successfully.

It relates to the following issue #s:
* Fixes https://github.com/sonatype-nexus-community/nexus-blobstore-google-cloud/issues/27
