### PR TITLE
Loading cache observability

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -156,7 +156,6 @@ public class GoogleCloudBlobStore
     wrapWithGauge(".liveBlobsCache.missCount", () -> liveBlobs.stats().missCount());
     wrapWithGauge(".liveBlobsCache.totalLoadTime", () -> liveBlobs.stats().totalLoadTime());
     wrapWithGauge(".liveBlobsCache.evictionCount", () -> liveBlobs.stats().evictionCount());
-    wrapWithGauge(".liveBlobsCache.loadCount", () -> liveBlobs.stats().loadCount());
     wrapWithGauge(".liveBlobsCache.requestCount", () -> liveBlobs.stats().requestCount());
     
     metricsStore.setBucket(bucket);
@@ -216,6 +215,7 @@ public class GoogleCloudBlobStore
 
   @Nullable
   @Override
+  @Guarded(by = STARTED)
   public Blob get(final BlobId blobId, final boolean includeDeleted) {
     checkNotNull(blobId);
 

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -149,7 +149,7 @@ public class GoogleCloudBlobStore
       metadata.setProperty(TYPE_KEY, TYPE_V1);
       metadata.store();
     }
-    liveBlobs = CacheBuilder.newBuilder().weakValues().build(from(GoogleCloudStorageBlob::new));
+    liveBlobs = CacheBuilder.newBuilder().weakValues().recordStats().build(from(GoogleCloudStorageBlob::new));
     
     wrapWithGauge(".liveBlobsCache.size", () -> liveBlobs.size());
     wrapWithGauge(".liveBlobsCache.hitCount", () -> liveBlobs.stats().hitCount());

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -60,7 +60,6 @@ import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageException;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 import com.google.common.hash.HashCode;
 import org.apache.commons.lang.StringUtils;
@@ -152,10 +151,13 @@ public class GoogleCloudBlobStore
     }
     liveBlobs = CacheBuilder.newBuilder().weakValues().build(from(GoogleCloudStorageBlob::new));
     
-    wrapWithGauge(".size", () -> liveBlobs.size());
-    wrapWithGauge(".hitRate", () -> liveBlobs.stats().hitRate());
-    wrapWithGauge(".missRate", () -> liveBlobs.stats().missRate());
-    wrapWithGauge(".averageLoadPenalty", () -> liveBlobs.stats().averageLoadPenalty());
+    wrapWithGauge(".liveBlobsCache.size", () -> liveBlobs.size());
+    wrapWithGauge(".liveBlobsCache.hitCount", () -> liveBlobs.stats().hitCount());
+    wrapWithGauge(".liveBlobsCache.missCount", () -> liveBlobs.stats().missCount());
+    wrapWithGauge(".liveBlobsCache.totalLoadTime", () -> liveBlobs.stats().totalLoadTime());
+    wrapWithGauge(".liveBlobsCache.evictionCount", () -> liveBlobs.stats().evictionCount());
+    wrapWithGauge(".liveBlobsCache.loadCount", () -> liveBlobs.stats().loadCount());
+    wrapWithGauge(".liveBlobsCache.requestCount", () -> liveBlobs.stats().requestCount());
     
     metricsStore.setBucket(bucket);
     metricsStore.setBlobStore(this);
@@ -172,6 +174,7 @@ public class GoogleCloudBlobStore
     metricRegistry.gauge(GoogleCloudBlobStore.class.getName() + nameSuffix,
         () -> () -> valueSupplier.get());
   }
+
   @Override
   protected Blob doCreate(final InputStream blobData,
                           final Map<String, String> headers,

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -24,6 +24,7 @@ import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 import org.sonatype.nexus.blobstore.api.BlobStoreException
 import org.sonatype.nexus.common.log.DryRunPrefix
 
+import com.codahale.metrics.MetricRegistry
 import com.google.api.gax.paging.Page
 import com.google.cloud.datastore.Datastore
 import com.google.cloud.datastore.KeyFactory
@@ -47,6 +48,8 @@ class GoogleCloudBlobStoreTest
 
   Bucket bucket = Mock()
 
+  MetricRegistry metricRegistry = Mock()
+
   GoogleCloudDatastoreFactory datastoreFactory = Mock()
 
   Datastore datastore = Mock()
@@ -58,7 +61,8 @@ class GoogleCloudBlobStoreTest
       (BlobStore.CREATED_BY_HEADER): 'admin'
   ]
   GoogleCloudBlobStore blobStore = new GoogleCloudBlobStore(
-      storageFactory, blobIdLocationResolver, metricsStore, datastoreFactory, new DryRunPrefix("TEST "))
+      storageFactory, blobIdLocationResolver, metricsStore, datastoreFactory, new DryRunPrefix("TEST "),
+      metricRegistry)
 
   def config = new BlobStoreConfiguration()
 


### PR DESCRIPTION
Nexus Repository Manager Blobstore implementations use a [Guava LoadingCache](https://github.com/google/guava/wiki/CachesExplained) around the identifiers for Blob assets.

We don't have enough visibility into the use of this cache (hit/miss/success/failure). This changeset registers a number of the LoadingCache metrics with NXRM's MetricRegistry.

The result is their presence in `/service/metrics/data`:

```
"org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.evictionCount": {
      "value": 5616
    },
    "org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.hitCount": {
      "value": 10577
    },
    "org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.missCount": {
      "value": 11124
    },
   "org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.requestCount": {
      "value": 21701
    },
    "org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.size": {
      "value": 672
    },
    "org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.liveBlobsCache.totalLoadTime": {
      "value": 52228060
    },
```

