### PR TITLE
update google client libraries to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <google-cloud.version>1.35.0</google-cloud.version>
+    <google-cloud.version>1.84.0</google-cloud.version>
   </properties>
 
   <dependencies>
@@ -68,6 +68,12 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
       <version>${google-cloud.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>1.30.1</version>
     </dependency>
 
     <dependency>
@@ -155,6 +161,10 @@
         <artifactId>karaf-maven-plugin</artifactId>
         <configuration>
           <excludedArtifactIds combine.children="append">
+            <id>protobuf-java-util</id>
+            <id>google-api-client</id>
+            <id>google-http-client</id>
+            <id>google-oauth-client</id>
             <id>grpc-core</id>
             <id>grpc-context</id>
           </excludedArtifactIds>

--- a/src/main/feature/feature.xml
+++ b/src/main/feature/feature.xml
@@ -18,6 +18,9 @@
     Relax protobuf import constraints so we can use latest release of Guava
     -->
     <bundle>wrap:${mvn:protobuf-java-util}$overwrite=merge&amp;Import-Package=com.google.common.*,*</bundle>
+    <bundle>wrap:${mvn:google-api-client}$overwrite=merge&amp;Import-Package=com.google.common.*,*</bundle>
+    <bundle>wrap:${mvn:google-http-client}$overwrite=merge&amp;Import-Package=com.google.common.*,*</bundle>
+    <bundle>wrap:${mvn:google-oauth-client}$overwrite=merge&amp;Import-Package=com.google.common.*,*</bundle>
     <bundle>wrap:${mvn:grpc-core}$Bundle-SymbolicName=grpc-core</bundle>
     <bundle>wrap:${mvn:grpc-context}$Bundle-SymbolicName=grpc-context&amp;Fragment-Host=grpc-core</bundle>
   </feature>


### PR DESCRIPTION
Includes some OSGi configuration to adapt to the NXRM environment. A big stumbling block was the guava dependency; the client libraries reference 26+, but only 25 is available in the container.

We also have to explicitly include google-oauth-client as a dependency as it is declared as a mandatory import by google-api-client, but not in the compile/runtime dependency hierarchy.

Fixes #41.

Big thank you to @mcculls for the guidance!