### PR TITLE
ShardedCounterMetricsStore lifecycle managed by container

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
@@ -136,7 +136,10 @@ public class ShardedCounterMetricsStore
         .setNamespace(namespace)
         .setKind(METRICS_STORE)
         .newKey(1L);
+  }
 
+  @Override
+  public void doStart() {
     this.flushJob = periodicJobService.schedule(() -> flush(), FLUSH_FREQUENCY_IN_SECONDS);
   }
 

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -62,6 +62,8 @@ class GoogleCloudBlobStoreTest
 
   BlobStoreQuotaService quotaService = Mock()
 
+  ShardedCounterMetricsStore metricsStore = Mock()
+
   KeyFactory keyFactory = new KeyFactory("testing")
 
   def blobHeaders = [
@@ -69,8 +71,8 @@ class GoogleCloudBlobStoreTest
       (BlobStore.CREATED_BY_HEADER): 'admin'
   ]
   GoogleCloudBlobStore blobStore = new GoogleCloudBlobStore(
-      storageFactory, blobIdLocationResolver, datastoreFactory, periodicJobService, new DryRunPrefix("TEST "),
-      metricRegistry, quotaService, 60)
+      storageFactory, blobIdLocationResolver, periodicJobService, metricsStore, datastoreFactory,
+      new DryRunPrefix("TEST "), metricRegistry, quotaService, 60)
 
   def config = new BlobStoreConfiguration()
 

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStoreIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStoreIT.groovy
@@ -18,6 +18,7 @@ import java.util.stream.IntStream
 import org.sonatype.nexus.blobstore.BlobIdLocationResolver
 import org.sonatype.nexus.blobstore.DefaultBlobIdLocationResolver
 import org.sonatype.nexus.blobstore.api.BlobId
+import org.sonatype.nexus.blobstore.api.BlobStore
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 import org.sonatype.nexus.scheduling.PeriodicJobService
 import org.sonatype.nexus.scheduling.PeriodicJobService.PeriodicJob
@@ -40,6 +41,8 @@ class ShardedCounterMetricsStoreIT
 
   GoogleCloudDatastoreFactory datastoreFactory = new GoogleCloudDatastoreFactory()
 
+  BlobStore blobStore = Mock()
+
   PeriodicJobService periodicJobService = Mock({
     schedule(_, _) >> new PeriodicJob() {
       @Override
@@ -59,11 +62,14 @@ class ShardedCounterMetricsStoreIT
     ]
   }
   def setup() {
+    blobStore.getBlobStoreConfiguration() >> config
     metricsStore = new ShardedCounterMetricsStore(blobIdLocationResolver, datastoreFactory, periodicJobService)
-    metricsStore.init(config)
+    metricsStore.setBlobStore(blobStore)
+    metricsStore.start()
   }
 
   def cleanup() {
+    metricsStore.stop()
     metricsStore.removeData()
   }
 


### PR DESCRIPTION
Previously, `GoogleCloudBlobStore` instances were responsible for managing their own instances of `ShardedCounterMetricsStore` outside of the DI container. This diversion was chosen previously since this plugin's MetricsStore does not extend from the `BlobStoreMetricsStoreSupport` class that other blobstore implementations use.

#43 indicates that this approach may be subject to a race condition, particularly when there are multiple Google Cloud BlobStores configured. The problem specifically is that the `ShardedCounterMetricsStore` might attempt to call `PeriodicScheduleService#schedule` (which is a managed instance) prior to it entering the `STARTED` state.

This pull request makes `ShardedCounterMetricsStore` a container managed bean, and re-plumbs initialization such that `PeriodicScheduleService#schedule` won't be called before it's started.

Fixes #43.
