### PR TITLE
feat: bucket location is now configurable

### DIFF
--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreIT.groovy
@@ -404,6 +404,7 @@ class GoogleCloudBlobStoreIT
     config.attributes = [
         'google cloud storage': [
             bucket: bucket,
+            location: 'us-central1',
             credential_file: this.getClass().getResource('/gce-credentials.json').getFile()
         ],
         (BlobStoreQuotaSupport.ROOT_KEY): [

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreTest.groovy
@@ -37,6 +37,7 @@ import com.google.cloud.datastore.KeyFactory
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.Storage.BlobListOption
+import com.google.cloud.storage.StorageClass
 import org.apache.commons.io.IOUtils
 import spock.lang.Specification
 
@@ -111,7 +112,10 @@ class GoogleCloudBlobStoreTest
   def setup() {
     storageFactory.create(_) >> storage
     config.name = 'GoogleCloudBlobStoreTest'
-    config.attributes = [ 'google cloud storage': [bucket: 'mybucket'] ]
+    config.attributes = [ 'google cloud storage': [
+        bucket: 'mybucket',
+        location: 'us-central1'
+    ] ]
 
     datastoreFactory.create(_) >> datastore
     datastore.newKeyFactory() >> keyFactory


### PR DESCRIPTION
Previously, the plugin would create the storage bucket using default values for location and storage class from the SDK (multi-regional, and us).

In this change set, we do the following:

* Allow the region to be passed in via BlobStoreConfiguration
* Present region in the UI to create a BlobStore
* Force a storage class of REGIONAL

The REGIONAL storage class provides the lowest latency and best repository manager performance (given the repository manager instance and the bucket have matching values for region).

Fixes #44. 

Screenshot of the new config UI:

<img width="1052" alt="Screen Shot 2019-10-12 at 3 47 18 PM" src="https://user-images.githubusercontent.com/1041730/66707620-c27cf080-ed08-11e9-8758-6ab659345bcd.png">

