### PR TITLE
WIP. Uses a UUID to normalize namespace name based on prefix and blob…

### DIFF
--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.uuidNamespace;
 
 /**
  * Index of soft-deleted {@link BlobId}s, stored in Google Datastore.
@@ -62,7 +63,7 @@ class DeletedBlobIndex
   DeletedBlobIndex(final GoogleCloudDatastoreFactory factory, final BlobStoreConfiguration blobStoreConfiguration)
       throws Exception {
     this.gcsDatastore = factory.create(blobStoreConfiguration);
-    this.namespace = NAMESPACE_PREFIX + blobStoreConfiguration.getName();
+    this.namespace = uuidNamespace(NAMESPACE_PREFIX, blobStoreConfiguration.getName());
     // this key factory will be used to add/remove blobIds from within the DELETED_BLOBS kind
     this.deletedBlobsKeyFactory = gcsDatastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Lists;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
-import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.uuidNamespace;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe;
 
 /**
  * Index of soft-deleted {@link BlobId}s, stored in Google Datastore.
@@ -63,7 +63,7 @@ class DeletedBlobIndex
   DeletedBlobIndex(final GoogleCloudDatastoreFactory factory, final BlobStoreConfiguration blobStoreConfiguration)
       throws Exception {
     this.gcsDatastore = factory.create(blobStoreConfiguration);
-    this.namespace = uuidNamespace(NAMESPACE_PREFIX, blobStoreConfiguration.getName());
+    this.namespace = namespaceSafe(NAMESPACE_PREFIX, blobStoreConfiguration.getName());
     // this key factory will be used to add/remove blobIds from within the DELETED_BLOBS kind
     this.deletedBlobsKeyFactory = gcsDatastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/DeletedBlobIndex.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Lists;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
-import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.safe;
 
 /**
  * Index of soft-deleted {@link BlobId}s, stored in Google Datastore.
@@ -63,7 +63,7 @@ class DeletedBlobIndex
   DeletedBlobIndex(final GoogleCloudDatastoreFactory factory, final BlobStoreConfiguration blobStoreConfiguration)
       throws Exception {
     this.gcsDatastore = factory.create(blobStoreConfiguration);
-    this.namespace = namespaceSafe(NAMESPACE_PREFIX, blobStoreConfiguration.getName());
+    this.namespace = NAMESPACE_PREFIX + safe(blobStoreConfiguration.getName());
     // this key factory will be used to add/remove blobIds from within the DELETED_BLOBS kind
     this.deletedBlobsKeyFactory = gcsDatastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
@@ -27,11 +27,10 @@ public class Namespace
   private Namespace() {
   }
 
-  public static String namespaceSafe(final String prefix, final String key) {
-    String composite = prefix + key;
-    if (GCP_NAMESPACE.matcher(composite).matches()) {
-      return composite;
+  public static String safe(final String key) {
+    if (GCP_NAMESPACE.matcher(key).matches()) {
+      return key;
     }
-    return nameUUIDFromBytes(composite.getBytes()).toString();
+    return nameUUIDFromBytes(key.getBytes()).toString();
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
@@ -1,0 +1,28 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import static java.util.UUID.nameUUIDFromBytes;
+
+/**
+ * Creates a GCP friendly namespace by using a subset of allowed characters in the form of a UUID type 3 value
+ */
+public class Namespace
+{
+  private Namespace() {
+  }
+
+  public static String uuidNamespace(final String prefix, final String key) {
+    return nameUUIDFromBytes((prefix + key).getBytes()).toString();
+  }
+}

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/Namespace.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.blobstore.gcloud.internal;
 
+import java.util.regex.Pattern;
+
 import static java.util.UUID.nameUUIDFromBytes;
 
 /**
@@ -19,10 +21,17 @@ import static java.util.UUID.nameUUIDFromBytes;
  */
 public class Namespace
 {
+
+  private static final Pattern GCP_NAMESPACE = Pattern.compile("^[0-9A-Za-z._\\-]{0,100}$");
+
   private Namespace() {
   }
 
-  public static String uuidNamespace(final String prefix, final String key) {
-    return nameUUIDFromBytes((prefix + key).getBytes()).toString();
+  public static String namespaceSafe(final String prefix, final String key) {
+    String composite = prefix + key;
+    if (GCP_NAMESPACE.matcher(composite).matches()) {
+      return composite;
+    }
+    return nameUUIDFromBytes(composite.getBytes()).toString();
   }
 }

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
@@ -61,7 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
-import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.safe;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
 
 /**
@@ -151,7 +151,7 @@ public class ShardedCounterMetricsStore
   public void doStart() throws Exception {
     BlobStoreConfiguration configuration = this.blobStore.getBlobStoreConfiguration();
     this.datastore = datastoreFactory.create(configuration);
-    this.namespace = namespaceSafe(NAMESPACE_PREFIX, configuration.getName());
+    this.namespace = NAMESPACE_PREFIX + safe(configuration.getName());
     this.shardRoot = datastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)
         .setNamespace(namespace)

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
@@ -61,6 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.uuidNamespace;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
 
 /**
@@ -150,7 +151,7 @@ public class ShardedCounterMetricsStore
   public void doStart() throws Exception {
     BlobStoreConfiguration configuration = this.blobStore.getBlobStoreConfiguration();
     this.datastore = datastoreFactory.create(configuration);
-    this.namespace = NAMESPACE_PREFIX + configuration.getName();
+    this.namespace = uuidNamespace(NAMESPACE_PREFIX, configuration.getName());
     this.shardRoot = datastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)
         .setNamespace(namespace)

--- a/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/ShardedCounterMetricsStore.java
@@ -61,7 +61,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NAMESPACE_PREFIX;
 import static org.sonatype.nexus.blobstore.gcloud.internal.DatastoreKeyHierarchy.NXRM_ROOT;
-import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.uuidNamespace;
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
 
 /**
@@ -151,7 +151,7 @@ public class ShardedCounterMetricsStore
   public void doStart() throws Exception {
     BlobStoreConfiguration configuration = this.blobStore.getBlobStoreConfiguration();
     this.datastore = datastoreFactory.create(configuration);
-    this.namespace = uuidNamespace(NAMESPACE_PREFIX, configuration.getName());
+    this.namespace = namespaceSafe(NAMESPACE_PREFIX, configuration.getName());
     this.shardRoot = datastore.newKeyFactory()
         .addAncestors(NXRM_ROOT)
         .setNamespace(namespace)

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/NamespaceTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/NamespaceTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype
+ * .com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License
+ * Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are
+ * trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe
+
+class NamespaceTest
+    extends Specification
+{
+
+  @Unroll
+  def "it will convert namespaces when containing illegal characters"() {
+    expect:
+      namespaceSafe(prefix, key) == expected
+    where:
+      prefix      | key      | expected
+      ''          | ''       | ''
+      'foo'       | 'bar'    | 'foobar'
+      'abc123ABC' | '._-'    | 'abc123ABC._-'
+      'fo oo'     | 'bar'    | 'c859195b-5a43-3ed8-a454-d3451a2a3daf'
+      'fo oo'     | 'ba ar'  | 'bb0dbdb5-3865-377e-ab2d-bec2622cac0f'
+      'foo$'      | 'bar$'   | '1502c3f6-1364-3d02-af8e-b7f5b6605e23'
+      'x' * 51    | 'y' * 50 | '5751745e-646f-37c8-8caa-8f0b54d64db5'
+  }
+}

--- a/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/NamespaceTest.groovy
+++ b/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/NamespaceTest.groovy
@@ -18,7 +18,7 @@ package org.sonatype.nexus.blobstore.gcloud.internal
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.namespaceSafe
+import static org.sonatype.nexus.blobstore.gcloud.internal.Namespace.safe
 
 class NamespaceTest
     extends Specification
@@ -27,15 +27,14 @@ class NamespaceTest
   @Unroll
   def "it will convert namespaces when containing illegal characters"() {
     expect:
-      namespaceSafe(prefix, key) == expected
+      safe(key) == expected
     where:
-      prefix      | key      | expected
-      ''          | ''       | ''
-      'foo'       | 'bar'    | 'foobar'
-      'abc123ABC' | '._-'    | 'abc123ABC._-'
-      'fo oo'     | 'bar'    | 'c859195b-5a43-3ed8-a454-d3451a2a3daf'
-      'fo oo'     | 'ba ar'  | 'bb0dbdb5-3865-377e-ab2d-bec2622cac0f'
-      'foo$'      | 'bar$'   | '1502c3f6-1364-3d02-af8e-b7f5b6605e23'
-      'x' * 51    | 'y' * 50 | '5751745e-646f-37c8-8caa-8f0b54d64db5'
+      key            | expected
+      ''             | ''
+      'bar'          | 'bar'
+      'abc123ABC._-' | 'abc123ABC._-'
+      'ba ar'        | '3ad6c2a6-5ccf-341c-ac0b-c670504de4dc'
+      'bar$'         | '08c15d2b-4a9f-3907-9763-4a0685b370ca'
+      'y' * 101      | '905b9d97-c7bb-3192-b6dc-f7fed334f708'
   }
 }


### PR DESCRIPTION
…store name.

Namespaces used within some of GCPs services have a strict character set such as `[0-9A-Za-z\._\-]{0,100}`. This change continues to use the same value but encoded using UUID type 3.

This pull request makes the following changes:
* Uses a consistent namespace format based on UUID type 3 with prefix and blob store name.

It relates to the following issue #s:
* Fixes https://github.com/sonatype-nexus-community/nexus-blobstore-google-cloud/issues/50

This PR does not address any migration that might be required for existing blob stores that would now have a changed namespace. Options could be to only use UUID format if the prefix+blob store name does not conform to the namespace regex.
