### PR TITLE
fix: remove last pathway that gzips content en route to bucket

### DIFF
--- a/nexus-blobstore-google-cloud-it/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDeploymentIT.java
+++ b/nexus-blobstore-google-cloud-it/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDeploymentIT.java
@@ -7,6 +7,10 @@ import org.junit.Test;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
+/**
+ * Integration test intended to deploy the plugin within Nexus Repository manager to confirm that the OSGi
+ * packaging is correct and the bundle will run.
+ */
 public class GoogleCloudBlobStoreDeploymentIT
   extends GoogleCloudBlobStoreITSupport
 {
@@ -21,6 +25,6 @@ public class GoogleCloudBlobStoreDeploymentIT
 
   @Test
   public void createGoogleCloudBlobStore() {
-    //assertNotNull(nxrm.getBlobStoreManager());
+    // no-op; this test will fail in inherited rule/before methods if the plugin is not successfully deployed
   }
 }

--- a/nexus-blobstore-google-cloud/pom.xml
+++ b/nexus-blobstore-google-cloud/pom.xml
@@ -63,11 +63,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
     </dependency>

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/MultipartUploader.java
@@ -36,6 +36,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.Storage.ComposeRequest;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
@@ -151,8 +152,7 @@ public class MultipartUploader
             BlobInfo blobInfo = BlobInfo.newBuilder(bucket, finalChunkName).build();
             // read the rest of the current stream
             // downside here is that since we don't know the stream size, we can't chunk it.
-            // the deprecated create method here does not allow us to disable GZIP compression on these PUTs
-            return storage.create(blobInfo, current);
+            return storage.create(blobInfo, current, BlobWriteOption.disableGzipContent());
           }));
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,29 +34,22 @@
   </modules>
 
   <properties>
-    <google-cloud.version>1.84.0</google-cloud.version>
+    <google-cloud-datastore.version>1.84.0</google-cloud-datastore.version>
+    <google-cloud-storage.version>1.104.0</google-cloud-storage.version>
     <nxrm-version>3.20.1-01</nxrm-version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage</artifactId>
-        <version>${google-cloud.version}</version>
+        <version>${google-cloud-storage.version}</version>
       </dependency>
-
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastore</artifactId>
-        <version>${google-cloud.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.oauth-client</groupId>
-        <artifactId>google-oauth-client</artifactId>
-        <version>1.30.1</version>
+        <version>${google-cloud-datastore.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
In #53, we found that disabling gzip compression unlocked some significant throughput gains. That change set left one remaining pathway where gzip compression would be performed by the `google-cloud-storage` dependency on blob content en route to the storage bucket.

The latest version of the `google-cloud-storage` dependency includes https://github.com/googleapis/java-storage/commit/65d3739567427e49ca4abfd39702fd4022ee8e3c, which allows us to turn off GZIP compression on that remaining pathway.

This pull request pulls in that new library version and makes the last change needed. 

The result is a 200% increase in throughput (47.7 requests/sec compared to 23.5 in #53):

![Screen Shot 2020-02-20 at 12 38 06 PM](https://user-images.githubusercontent.com/1041730/74967057-dda9ec00-53dd-11ea-98ad-efceefb8831d.png)

Stackdriver Profiler confirms the reduction in CPU utilization, dropping the CPU time spent on handling client requests to/from the bucket from 18.5% down to 1.1%:

![Screen Shot 2020-02-20 at 12 27 21 PM](https://user-images.githubusercontent.com/1041730/74967300-5315bc80-53de-11ea-93ad-ac3a26388423.png)

Fixes #56 .
