### PR TITLE
deploy using 'circleci-maven-release-orb', and some other goodies.

### DIFF
--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -1,0 +1,65 @@
+<!--
+
+    Sonatype Nexus (TM) Open Source Version
+    Copyright (c) 2020-present Sonatype, Inc.
+    All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+
+    Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+    of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+    Eclipse Foundation. All other trademarks are the property of their respective owners.
+
+-->
+
+CI Debug Notes
+================
+To validate some circleci stuff, I was able to run a “build locally” using the steps below.
+The local build runs in a docker container.
+
+  * (Once) Install circleci client (`brew install circleci`)
+
+  * Convert the “real” config.yml into a self contained (non-workspace) config via:
+
+        circleci config process .circleci/config.yml > .circleci/local-config.yml
+
+  * Run a local build with the following command:
+          
+        circleci local execute -c .circleci/local-config.yml --job 'github-maven-deploy/build-and-test'
+
+    Typically both commands are run together:
+    
+        circleci config process .circleci/config.yml > .circleci/local-config.yml && circleci local execute -c .circleci/local-config.yml --job 'github-maven-deploy/build-and-test'
+    
+    With the above command, operations that cannot occur during a local build will show an error like this:
+     
+      ```
+      ... Error: FAILED with error not supported
+      ```
+    
+      However, the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.
+      
+      If the build does complete successfully, you should see a happy yellow `Success!` message.
+
+Miscellaneous
+-------------
+
+To allow your CI build to push changes back to github (e.g. release tags, etc), you need to create setup
+ a github "Deploy Key" with write access. The command below will create such a key. Use an empty password.
+ See: https://circleci.com/docs/2.0/add-ssh-key/#steps
+
+    ssh-keygen -m PEM -t rsa -b 4096 -C "community-group@sonatype.com" -f <project-name>_github_rsa.key
+    
+Paste the public key into a new "write" enabled GitHub deploy key with Title: CircleCI Write <project name>
+
+Be sure you check the "Allow write access" option.
+
+    cat <project-name>_github_rsa.key.pub | pbcopy
+    
+In the CircleCI Web UI, under Permissions -> SSH Permissions -> Add SSH Key, enter "Hostname": github.com
+
+Paste the private key.
+
+    cat <project-name>_github_rsa.key | pbcopy        
+
+As a sanity check, the private key should end with `-----END RSA PRIVATE KEY-----`.
+
+Also update the `ssh-fingerprints:` tag in your config.yml to append the fingerprint of the write key.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,10 @@
 version: 2.1
 orbs:
   github-maven-deploy: github-maven-deploy/github-maven-deploy@1.0.5
+  circleci-maven-release-orb: sonatype-nexus-community/circleci-maven-release-orb@0.0.15
 
 mvn-build-test-command: &mvn-build-test-command
   mvn-build-test-command: mvn clean package -PbuildKar
-
-mvn-deploy-command: &mvn-deploy-command
-  mvn-deploy-command: mvn -s .circleci/.maven.xml clean deploy -PbuildKar -DdeployAtEnd=true -DperformRelease=true -DskipTests -Dspotbugs.skip=true
-  context: rso-base
 
 mvn-collect-artifacts-command: &mvn-collect-artifacts-command
   mvn-collect-artifacts-command: |
@@ -16,50 +13,27 @@ mvn-collect-artifacts-command: &mvn-collect-artifacts-command
     cp ~/project/nexus-blobstore-google-cloud/target/nexus-blobstore-* ~/project/artifacts/
 
 workflows:
-  workflow:
+  build-and-test:
     jobs:
       - github-maven-deploy/build-and-test:
-          <<: *mvn-build-test-command
-          <<: *mvn-collect-artifacts-command
-      - github-maven-deploy/approve-deploy-patch-version:
+          mvn-build-test-command: mvn clean package -PbuildKar
+          mvn-collect-artifacts-command: |
+            mkdir -p ~/project/artifacts/junit/
+            cp ~/project/nexus-blobstore-google-cloud/target/surefire-reports/*.xml ~/project/artifacts/junit/
+            cp ~/project/nexus-blobstore-google-cloud/target/nexus-blobstore-* ~/project/artifacts/
+
+  run-release:
+    jobs:
+      - approve-release:
           type: approval
-          requires:
-            - github-maven-deploy/build-and-test
           filters:
             branches:
               only: master
-      - github-maven-deploy/approve-deploy-minor-version:
-          type: approval
+      - circleci-maven-release-orb/run-maven-release:
           requires:
-            - github-maven-deploy/build-and-test
-          filters:
-            branches:
-              only: master
-      - github-maven-deploy/approve-deploy-major-version:
-          type: approval
-          requires:
-            - github-maven-deploy/build-and-test
-          filters:
-            branches:
-              only: master
-      - github-maven-deploy/deploy-patch-version:
-          requires:
-            - github-maven-deploy/approve-deploy-patch-version
-          <<: *mvn-deploy-command
-          filters:
-            branches:
-              only: master
-      - github-maven-deploy/deploy-minor-version:
-          requires:
-            - github-maven-deploy/approve-deploy-minor-version
-          <<: *mvn-deploy-command
-          filters:
-            branches:
-              only: master
-      - github-maven-deploy/deploy-major-version:
-          requires:
-            - github-maven-deploy/approve-deploy-major-version
-          <<: *mvn-deploy-command
+            - approve-release
+          ssh-fingerprints: "25:1d:9f:0d:ac:7a:0e:19:e3:1c:25:53:d2:cb:13:cc"
+          context: rso-base
           filters:
             branches:
               only: master

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ target/
 *~
 **/gce-credentials.json
 **/src/test/resources/large_file
+
+# ci config for local ci build
+.circleci/local-config.yml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Nexus Repository Google Cloud Storage Blobstore
 ==============================
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.sonatype.nexus.plugins/nexus-blobstore-google-cloud.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-blobstore-google-cloud%22) [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![CircleCI Build Status](https://circleci.com/gh/sonatype-nexus-community/nexus-blobstore-google-cloud.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/sonatype-nexus-community/nexus-blobstore-google-cloud) [![Maven Central](https://img.shields.io/maven-central/v/org.sonatype.nexus.plugins/nexus-blobstore-google-cloud.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-blobstore-google-cloud%22) [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This project adds [Google Cloud Object Storage](https://cloud.google.com/storage/) backed blobstores to Sonatype Nexus 
 Repository 3 and later.  It allows Nexus Repository to store the components and assets in Google Cloud instead of a


### PR DESCRIPTION
This PR uses a new Orb to do deployment to maven central. It is simpler in that it pretty much just deploys "patch" (major.minor.patch+1) release versions.

I also through in a new badge and some CI doco for the curious.