### PR TITLE
REST API for creating/managing blob store

### DIFF
--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -82,6 +82,7 @@ import static org.sonatype.nexus.blobstore.DirectPathLocationStrategy.DIRECT_PAT
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.createQuotaCheckJob;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.FAILED;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.NEW;
+import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.SHUTDOWN;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STARTED;
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STOPPED;
 
@@ -449,7 +450,7 @@ public class GoogleCloudBlobStore
   }
 
   @Override
-  @Guarded(by = {NEW, STOPPED, FAILED})
+  @Guarded(by = {NEW, STOPPED, FAILED, SHUTDOWN})
   public void remove() {
     metricsStore.removeData();
     deletedBlobIndex.removeData();

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
@@ -17,6 +17,7 @@ import javax.validation.constraints.NotNull;
 
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
 import org.sonatype.nexus.blobstore.rest.BlobStoreApiSoftQuota;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
 
 import io.swagger.annotations.ApiModelProperty;
 
@@ -55,9 +56,13 @@ public class GoogleCloudBlobstoreApiModel
     this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_KEY, String.class);
     this.region = configuration.attributes(CONFIG_KEY).get(LOCATION_KEY, String.class);
 
-    BlobStoreApiSoftQuota softQuota = new BlobStoreApiSoftQuota();
-    softQuota.setLimit(configuration.attributes(ROOT_KEY).get(LIMIT_KEY, Long.class));
-    softQuota.setType(configuration.attributes(ROOT_KEY).get(TYPE_KEY, String.class));
+    NestedAttributesMap softQuotaAttributes = configuration.attributes(ROOT_KEY);
+    if (softQuotaAttributes != null) {
+      BlobStoreApiSoftQuota softQuota = new BlobStoreApiSoftQuota();
+      softQuota.setLimit(configuration.attributes(ROOT_KEY).get(LIMIT_KEY, Long.class));
+      softQuota.setType(configuration.attributes(ROOT_KEY).get(TYPE_KEY, String.class));
+      this.softQuota = softQuota;
+    }
   }
 
   public String getName() {

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
@@ -1,0 +1,94 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal.rest;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.blobstore.rest.BlobStoreApiSoftQuota;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.LOCATION_KEY;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.TYPE_KEY;
+
+/**
+ * Transfer object model for REST API.
+ */
+public class GoogleCloudBlobstoreApiModel
+{
+  @NotBlank
+  @ApiModelProperty("The name of the blob store")
+  private String name;
+
+  @NotBlank
+  @ApiModelProperty("The name of the bucket in Google Cloud Storage")
+  private String bucketName;
+
+  @NotBlank
+  @ApiModelProperty("The name of the region where the bucket is stored, e.g. us-central1")
+  private String region;
+
+  @ApiModelProperty("Settings to control the soft quota.")
+  private BlobStoreApiSoftQuota softQuota;
+
+  public GoogleCloudBlobstoreApiModel() {
+  }
+
+  GoogleCloudBlobstoreApiModel(BlobStoreConfiguration configuration) {
+    this.name = configuration.getName();
+    this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_KEY, String.class);
+    this.region = configuration.attributes(CONFIG_KEY).get(LOCATION_KEY, String.class);
+
+    BlobStoreApiSoftQuota softQuota = new BlobStoreApiSoftQuota();
+    softQuota.setLimit(configuration.attributes(ROOT_KEY).get(LIMIT_KEY, Long.class));
+    softQuota.setType(configuration.attributes(ROOT_KEY).get(TYPE_KEY, String.class));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public void setBucketName(final String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
+  }
+
+  public BlobStoreApiSoftQuota getSoftQuota() {
+    return softQuota;
+  }
+
+  public void setSoftQuota(final BlobStoreApiSoftQuota softQuota) {
+    this.softQuota = softQuota;
+  }
+}

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -1,0 +1,141 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal.rest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import org.sonatype.goodies.common.ComponentSupport;
+import org.sonatype.nexus.blobstore.api.BlobStore;
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.blobstore.api.BlobStoreManager;
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.rest.Resource;
+
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.LOCATION_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.rest.GoogleCloudBlobstoreApiResource.RESOURCE_URI;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
+import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.TYPE_KEY;
+import static org.sonatype.nexus.rest.APIConstants.BETA_API_PREFIX;
+
+/**
+ * REST API for managing Google Cloud blob stores.
+ */
+@Named
+@Singleton
+@Path(RESOURCE_URI)
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+public class GoogleCloudBlobstoreApiResource
+    extends ComponentSupport
+    implements Resource, GoogleCloudBlobstoreApiResourceDoc
+{
+  static final String RESOURCE_URI = BETA_API_PREFIX + "/blobstores/google";
+
+  static final int ONE_MILLION = 1_000_000;
+
+  private final BlobStoreManager blobStoreManager;
+
+  @Inject
+  public GoogleCloudBlobstoreApiResource(BlobStoreManager blobStoreManager) {
+    this.blobStoreManager = blobStoreManager;
+  }
+
+  @GET
+  @RequiresAuthentication
+  @Path("/{name}")
+  @RequiresPermissions("nexus:blobstores:read")
+  @Override
+  public GoogleCloudBlobstoreApiModel get(final String blobStoreName) {
+    BlobStore blobStore = blobStoreManager.get(blobStoreName);
+    if (blobStore == null) {
+      return null;
+    }
+    return new GoogleCloudBlobstoreApiModel(blobStore.getBlobStoreConfiguration());
+  }
+
+  @POST
+  @RequiresAuthentication
+  @RequiresPermissions("nexus:blobstores:create")
+  @Override
+  public GoogleCloudBlobstoreApiModel create(@Valid final GoogleCloudBlobstoreApiModel blobstoreApiModel)
+      throws Exception
+  {
+    if (blobStoreManager.get(blobstoreApiModel.getName()) != null) {
+      throw new IllegalArgumentException("A blob store with that name already exists");
+    }
+    BlobStoreConfiguration config = blobStoreManager.newConfiguration();
+    merge(config, blobstoreApiModel);
+    BlobStore blobStore = blobStoreManager.create(config);
+    return new GoogleCloudBlobstoreApiModel(blobStore.getBlobStoreConfiguration());
+  }
+
+  @PUT
+  @RequiresAuthentication
+  @Path("/{name}")
+  @RequiresPermissions("nexus:blobstores:update")
+  @Override
+  public GoogleCloudBlobstoreApiModel update(@PathParam("name") final String blobStoreName,
+                                             @Valid final GoogleCloudBlobstoreApiModel blobstoreApiModel)
+      throws Exception
+  {
+    BlobStore existing = blobStoreManager.get(blobStoreName);
+    if (existing == null) {
+      return null;
+    }
+    BlobStoreConfiguration config = existing.getBlobStoreConfiguration();
+    if (config.getType() != GoogleCloudBlobStore.TYPE) {
+      throw new IllegalArgumentException("Use this API only for blob stores with type " + GoogleCloudBlobStore.TYPE);
+    }
+    merge(config, blobstoreApiModel);
+
+    BlobStore blobStore = blobStoreManager.update(config);
+    return new GoogleCloudBlobstoreApiModel(blobStore.getBlobStoreConfiguration());
+  }
+
+  /**
+   * @param config the configuration to be updated
+   * @param blobstoreApiModel the source of new values
+   */
+  void merge(BlobStoreConfiguration config, GoogleCloudBlobstoreApiModel blobstoreApiModel) {
+    config.setName(blobstoreApiModel.getName());
+    NestedAttributesMap bucket = config.attributes(CONFIG_KEY);
+    bucket.set(BUCKET_KEY, blobstoreApiModel.getBucketName());
+    bucket.set(LOCATION_KEY, blobstoreApiModel.getRegion());
+
+    if (blobstoreApiModel.getSoftQuota() != null ) {
+      NestedAttributesMap softQuota = config.attributes(ROOT_KEY);
+      softQuota.set(TYPE_KEY, checkNotNull(blobstoreApiModel.getSoftQuota().getType()));
+      final Long softQuotaLimit = checkNotNull(blobstoreApiModel.getSoftQuota().getLimit());
+      softQuota.set(LIMIT_KEY, softQuotaLimit * ONE_MILLION);
+    }
+  }
+}

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -17,12 +17,15 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.blobstore.api.BlobStore;
@@ -119,6 +122,20 @@ public class GoogleCloudBlobstoreApiResource
 
     BlobStore blobStore = blobStoreManager.update(config);
     return new GoogleCloudBlobstoreApiModel(blobStore.getBlobStoreConfiguration());
+  }
+
+  @DELETE
+  @RequiresAuthentication
+  @Path("/{name}")
+  @RequiresPermissions("nexus:blobstores:delete")
+  public Response delete(@PathParam("name") final String name) throws Exception {
+    BlobStore existing = blobStoreManager.get(name);
+    if (existing == null) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    BlobStoreConfiguration config = confirmType(existing.getBlobStoreConfiguration());
+    blobStoreManager.delete(config.getName());
+    return Response.noContent().build();
   }
 
   /**

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -34,6 +34,7 @@ import org.sonatype.nexus.blobstore.api.BlobStoreManager;
 import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore;
 import org.sonatype.nexus.common.collect.NestedAttributesMap;
 import org.sonatype.nexus.rest.Resource;
+import org.sonatype.nexus.rest.WebApplicationMessageException;
 
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
@@ -79,7 +80,6 @@ public class GoogleCloudBlobstoreApiResource
   @Override
   public GoogleCloudBlobstoreApiModel get(@PathParam("name") final String name) {
     BlobStore blobStore = blobStoreManager.get(name);
-    log.error("{}", blobStore);
     if (blobStore == null) {
       return null;
     }
@@ -95,7 +95,7 @@ public class GoogleCloudBlobstoreApiResource
       throws Exception
   {
     if (blobStoreManager.get(model.getName()) != null) {
-      throw new IllegalArgumentException("A blob store with that name already exists");
+      throw new WebApplicationMessageException(Status.BAD_REQUEST, "A blob store with that name already exists");
     }
     BlobStoreConfiguration config = blobStoreManager.newConfiguration();
     config.setType(GoogleCloudBlobStore.TYPE);
@@ -141,11 +141,11 @@ public class GoogleCloudBlobstoreApiResource
   /**
    * @param config to check
    * @return the configuration if it is of {@link GoogleCloudBlobStore#TYPE}
-   * @throws IllegalArgumentException if it is any other type
+   * @throws WebApplicationMessageException if it is any other type
    */
   BlobStoreConfiguration confirmType(BlobStoreConfiguration config) {
     if (!GoogleCloudBlobStore.TYPE.equals(config.getType())) {
-      throw new IllegalArgumentException("Use this API only for blob stores with type " + GoogleCloudBlobStore.TYPE);
+      throw new WebApplicationMessageException(Status.BAD_REQUEST, "Use this API only for blob stores with type " + GoogleCloudBlobStore.TYPE);
     }
     return config;
   }

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
@@ -13,6 +13,7 @@
 package org.sonatype.nexus.blobstore.gcloud.internal.rest;
 
 import javax.validation.Valid;
+import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -36,7 +37,7 @@ public interface GoogleCloudBlobstoreApiResourceDoc
           @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND),
       }
   )
-  GoogleCloudBlobstoreApiModel get(@ApiParam("the name of the blobstore") String name);
+  GoogleCloudBlobstoreApiModel get(@ApiParam("the name of the blob store") String name);
 
   @ApiOperation("Create a Google Cloud blob store")
   @ApiResponses(value = {
@@ -56,4 +57,13 @@ public interface GoogleCloudBlobstoreApiResourceDoc
   GoogleCloudBlobstoreApiModel update(@ApiParam("the name of the blobstore") String name,
                                       @Valid GoogleCloudBlobstoreApiModel blobstoreApiModel)
       throws Exception;
+
+  @ApiOperation("Delete a Google Cloud blob store")
+  @ApiResponses(value = {
+      @ApiResponse(code = 204, message = "Google Cloud blob store deleted"),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS),
+      @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND)
+  })
+  Response delete(@ApiParam("the name of the blob store") String name) throws Exception;
 }

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
@@ -1,0 +1,56 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal.rest;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import static org.sonatype.nexus.rest.ApiDocConstants.API_BLOB_STORE;
+import static org.sonatype.nexus.rest.ApiDocConstants.AUTHENTICATION_REQUIRED;
+import static org.sonatype.nexus.rest.ApiDocConstants.INSUFFICIENT_PERMISSIONS;
+import static org.sonatype.nexus.rest.ApiDocConstants.REPOSITORY_NOT_FOUND;
+
+@Api(API_BLOB_STORE)
+public interface GoogleCloudBlobstoreApiResourceDoc
+{
+  @ApiOperation("Get the configuration for a Google Cloud blob store")
+  @ApiResponses(
+      value = {
+          @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+          @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS),
+          @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND),
+      }
+  )
+  GoogleCloudBlobstoreApiModel get(@ApiParam(value = "Name of the blob store") String blobStoreName);
+
+  @ApiOperation("Create a Google Cloud blob store")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = "Google Cloud blob store created"),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
+  })
+  GoogleCloudBlobstoreApiModel create(GoogleCloudBlobstoreApiModel blobstoreApiModel) throws Exception;
+
+  @ApiOperation("Update a Google Cloud blob store")
+  @ApiResponses(value = {
+      @ApiResponse(code = 201, message = "Google Cloud blob store updated"),
+      @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
+      @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS),
+      @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND)
+  })
+  GoogleCloudBlobstoreApiModel update(String blobStoreName, GoogleCloudBlobstoreApiModel blobstoreApiModel)
+      throws Exception;
+}

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceDoc.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.blobstore.gcloud.internal.rest;
 
+import javax.validation.Valid;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -34,7 +36,7 @@ public interface GoogleCloudBlobstoreApiResourceDoc
           @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND),
       }
   )
-  GoogleCloudBlobstoreApiModel get(@ApiParam(value = "Name of the blob store") String blobStoreName);
+  GoogleCloudBlobstoreApiModel get(@ApiParam("the name of the blobstore") String name);
 
   @ApiOperation("Create a Google Cloud blob store")
   @ApiResponses(value = {
@@ -42,7 +44,7 @@ public interface GoogleCloudBlobstoreApiResourceDoc
       @ApiResponse(code = 401, message = AUTHENTICATION_REQUIRED),
       @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS)
   })
-  GoogleCloudBlobstoreApiModel create(GoogleCloudBlobstoreApiModel blobstoreApiModel) throws Exception;
+  GoogleCloudBlobstoreApiModel create(@Valid GoogleCloudBlobstoreApiModel blobstoreApiModel) throws Exception;
 
   @ApiOperation("Update a Google Cloud blob store")
   @ApiResponses(value = {
@@ -51,6 +53,7 @@ public interface GoogleCloudBlobstoreApiResourceDoc
       @ApiResponse(code = 403, message = INSUFFICIENT_PERMISSIONS),
       @ApiResponse(code = 404, message = REPOSITORY_NOT_FOUND)
   })
-  GoogleCloudBlobstoreApiModel update(String blobStoreName, GoogleCloudBlobstoreApiModel blobstoreApiModel)
+  GoogleCloudBlobstoreApiModel update(@ApiParam("the name of the blobstore") String name,
+                                      @Valid GoogleCloudBlobstoreApiModel blobstoreApiModel)
       throws Exception;
 }

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -16,6 +16,8 @@ import org.sonatype.nexus.blobstore.MockBlobStoreConfiguration
 import org.sonatype.nexus.blobstore.api.BlobStore
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
 import org.sonatype.nexus.blobstore.api.BlobStoreManager
+import org.sonatype.nexus.blobstore.file.FileBlobStore
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore
 import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport
 import org.sonatype.nexus.blobstore.quota.internal.SpaceUsedQuota
 
@@ -53,6 +55,21 @@ class GoogleCloudBlobstoreApiResourceTest
       model.name == 'apitest'
   }
 
+  def "get throws exception for non-google type"() {
+    given:
+      def fileconfig = makeConfig('file')
+      fileconfig.type = FileBlobStore.TYPE
+      BlobStore fileblobstore = Mock()
+      fileblobstore.getBlobStoreConfiguration() >> fileconfig
+      blobStoreManager.get('file') >> fileblobstore
+
+    when:
+      GoogleCloudBlobstoreApiModel model = api.get('file')
+
+    then:
+      thrown(IllegalArgumentException)
+  }
+
   def "create prevents duplicates"() {
     when:
       api.create(new GoogleCloudBlobstoreApiModel(config))
@@ -64,6 +81,7 @@ class GoogleCloudBlobstoreApiResourceTest
   def makeConfig(String name) {
     BlobStoreConfiguration result = new MockBlobStoreConfiguration()
     result.name = name
+    result.type = GoogleCloudBlobStore.TYPE
     result.attributes = [
         'google cloud storage': [
             bucket: 'bucketname',

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -12,6 +12,9 @@
  */
 package org.sonatype.nexus.blobstore.gcloud.internal.rest
 
+import javax.ws.rs.core.Response
+import javax.ws.rs.core.Response.Status
+
 import org.sonatype.nexus.blobstore.MockBlobStoreConfiguration
 import org.sonatype.nexus.blobstore.api.BlobStore
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
@@ -64,7 +67,7 @@ class GoogleCloudBlobstoreApiResourceTest
       blobStoreManager.get('file') >> fileblobstore
 
     when:
-      GoogleCloudBlobstoreApiModel model = api.get('file')
+      api.get('file')
 
     then:
       thrown(IllegalArgumentException)
@@ -76,6 +79,30 @@ class GoogleCloudBlobstoreApiResourceTest
 
     then:
       thrown(IllegalArgumentException.class)
+  }
+
+  def "successful delete"() {
+    when:
+      Response response = api.delete('apitest')
+
+    then:
+      1 * blobStoreManager.delete('apitest')
+      response.status == Status.NO_CONTENT.statusCode
+  }
+
+  def "delete throws exception for non-google type"() {
+    given:
+      def fileconfig = makeConfig('file')
+      fileconfig.type = FileBlobStore.TYPE
+      BlobStore fileblobstore = Mock()
+      fileblobstore.getBlobStoreConfiguration() >> fileconfig
+      blobStoreManager.get('file') >> fileblobstore
+
+    when:
+      api.delete('file')
+
+    then:
+      thrown(IllegalArgumentException)
   }
 
   def makeConfig(String name) {

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -23,6 +23,7 @@ import org.sonatype.nexus.blobstore.file.FileBlobStore
 import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore
 import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport
 import org.sonatype.nexus.blobstore.quota.internal.SpaceUsedQuota
+import org.sonatype.nexus.rest.WebApplicationMessageException
 
 import spock.lang.Specification
 
@@ -33,12 +34,13 @@ class GoogleCloudBlobstoreApiResourceTest
 
   BlobStoreManager blobStoreManager = Mock()
 
+  BlobStore blobstore = Mock()
+
   GoogleCloudBlobstoreApiResource api = new GoogleCloudBlobstoreApiResource(blobStoreManager)
 
   def setup() {
     config = makeConfig('apitest')
 
-    BlobStore blobstore = Mock()
     blobstore.getBlobStoreConfiguration() >> config
     blobStoreManager.get('apitest') >> blobstore
 
@@ -70,7 +72,7 @@ class GoogleCloudBlobstoreApiResourceTest
       api.get('file')
 
     then:
-      thrown(IllegalArgumentException)
+      thrown(WebApplicationMessageException)
   }
 
   def "create prevents duplicates"() {
@@ -78,7 +80,7 @@ class GoogleCloudBlobstoreApiResourceTest
       api.create(new GoogleCloudBlobstoreApiModel(config))
 
     then:
-      thrown(IllegalArgumentException.class)
+      thrown(WebApplicationMessageException)
   }
 
   def "successful delete"() {
@@ -102,7 +104,7 @@ class GoogleCloudBlobstoreApiResourceTest
       api.delete('file')
 
     then:
-      thrown(IllegalArgumentException)
+      thrown(WebApplicationMessageException)
   }
 
   def makeConfig(String name) {

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal.rest
+
+import org.sonatype.nexus.blobstore.MockBlobStoreConfiguration
+import org.sonatype.nexus.blobstore.api.BlobStore
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration
+import org.sonatype.nexus.blobstore.api.BlobStoreManager
+import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport
+import org.sonatype.nexus.blobstore.quota.internal.SpaceUsedQuota
+
+import spock.lang.Specification
+
+class GoogleCloudBlobstoreApiResourceTest
+  extends Specification
+{
+  static BlobStoreConfiguration config = new MockBlobStoreConfiguration()
+
+  BlobStoreManager blobStoreManager = Mock()
+
+  GoogleCloudBlobstoreApiResource api = new GoogleCloudBlobstoreApiResource(blobStoreManager)
+
+  def setup() {
+    config = makeConfig('apitest')
+  }
+
+  def "returns null for not found"() {
+    expect:
+      api.get('undefined') == null
+  }
+
+  def "returns config for existing store"() {
+    given:
+      BlobStore blobstore = Mock()
+      blobstore.getBlobStoreConfiguration() >> config
+      blobStoreManager.get('apitest') >> blobstore
+
+    when:
+      GoogleCloudBlobstoreApiModel model = api.get('apitest')
+
+    then:
+      model.name == 'apitest'
+  }
+
+  def "create prevents duplicates"() {
+    given:
+      BlobStore blobstore = Mock()
+      blobstore.getBlobStoreConfiguration() >> config
+      blobStoreManager.get('apitest') >> blobstore
+
+    when:
+      api.create(new GoogleCloudBlobstoreApiModel(makeConfig('apitest')))
+
+    then:
+      thrown(IllegalArgumentException)
+  }
+
+  def "create success"() {
+    given:
+      def createConf = makeConfig('createtest')
+      def model = new GoogleCloudBlobstoreApiModel(createConf)
+
+    when:
+      GoogleCloudBlobstoreApiModel result = api.create(model)
+
+    then:
+      result.name == 'createtest'
+  }
+
+  def makeConfig(String name) {
+    BlobStoreConfiguration result = new MockBlobStoreConfiguration()
+    config.name = name
+    config.attributes = [
+        'google cloud storage': [
+            bucket: 'bucketname',
+            location: 'us-central1'
+        ],
+        (BlobStoreQuotaSupport.ROOT_KEY): [
+            (BlobStoreQuotaSupport.TYPE_KEY): (SpaceUsedQuota.ID),
+            (BlobStoreQuotaSupport.LIMIT_KEY): (512000L)
+        ]
+    ]
+    return result
+  }
+}

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -32,6 +32,12 @@ class GoogleCloudBlobstoreApiResourceTest
 
   def setup() {
     config = makeConfig('apitest')
+
+    BlobStore blobstore = Mock()
+    blobstore.getBlobStoreConfiguration() >> config
+    blobStoreManager.get('apitest') >> blobstore
+
+    blobStoreManager.newConfiguration() >> new MockBlobStoreConfiguration()
   }
 
   def "returns null for not found"() {
@@ -39,12 +45,7 @@ class GoogleCloudBlobstoreApiResourceTest
       api.get('undefined') == null
   }
 
-  def "returns config for existing store"() {
-    given:
-      BlobStore blobstore = Mock()
-      blobstore.getBlobStoreConfiguration() >> config
-      blobStoreManager.get('apitest') >> blobstore
-
+  def "get returns config for existing store"() {
     when:
       GoogleCloudBlobstoreApiModel model = api.get('apitest')
 
@@ -53,34 +54,17 @@ class GoogleCloudBlobstoreApiResourceTest
   }
 
   def "create prevents duplicates"() {
-    given:
-      BlobStore blobstore = Mock()
-      blobstore.getBlobStoreConfiguration() >> config
-      blobStoreManager.get('apitest') >> blobstore
-
     when:
-      api.create(new GoogleCloudBlobstoreApiModel(makeConfig('apitest')))
+      api.create(new GoogleCloudBlobstoreApiModel(config))
 
     then:
-      thrown(IllegalArgumentException)
-  }
-
-  def "create success"() {
-    given:
-      def createConf = makeConfig('createtest')
-      def model = new GoogleCloudBlobstoreApiModel(createConf)
-
-    when:
-      GoogleCloudBlobstoreApiModel result = api.create(model)
-
-    then:
-      result.name == 'createtest'
+      thrown(IllegalArgumentException.class)
   }
 
   def makeConfig(String name) {
     BlobStoreConfiguration result = new MockBlobStoreConfiguration()
-    config.name = name
-    config.attributes = [
+    result.name = name
+    result.attributes = [
         'google cloud storage': [
             bucket: 'bucketname',
             location: 'us-central1'


### PR DESCRIPTION
This pull request adds a new REST API to allow administrators to create and manage Google Cloud Blobstores.

When the plugin is installed, this new API snaps in to the existing blobstore API:

![Screen Shot 2020-05-11 at 2 47 46 PM](https://user-images.githubusercontent.com/1041730/81750455-24563200-9473-11ea-837b-aad375e46a6c.png)
