### PR TITLE
Temporarily exclude community plugins from IT module dependencies

### DIFF
--- a/nexus-blobstore-google-cloud-it/pom.xml
+++ b/nexus-blobstore-google-cloud-it/pom.xml
@@ -84,21 +84,7 @@
       <scope>test</scope>
       <exclusions>
         <!--
-          temporarily exclude helm and conan as they have non-public dependencies
-        -->
-        <!--
-        <exclusion>
-          <groupId>org.sonatype.nexus.plugins</groupId>
-          <artifactId>nexus-repository-helm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.nexus.plugins</groupId>
-          <artifactId>nexus-repository-conan</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.nexus.plugins</groupId>
-          <artifactId>nexus-repository-p2</artifactId>
-        </exclusion>
+          temporarily exclude community plugins as they have non-public dependencies
         -->
         <exclusion>
           <groupId>org.sonatype.nexus.assemblies</groupId>


### PR DESCRIPTION
Nexus Repository Manager 3.26.1-02 includes a number of community plugins that have references to version 3.26.1-01 of the parent pom, which is not publicly available. This results in build failures for modules that depend on `nexus-base-template` (which the -it module in this project does) outside of the Sonatype infrastructure (like on CircleCI).

This pull request excludes the affected modules from the local -it module. This means that the integration tests that spin up NXRM instances don't have the community modules installed. The integration tests for this plugin do not depend on those plugins, so that resolves the build issue and the tests are confirmed to complete successfully.

Fixes #78 