### PR TITLE
feat: add support for credential_file via REST API

### DIFF
--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
@@ -14,15 +14,14 @@ package org.sonatype.nexus.blobstore.gcloud.internal.rest;
 
 import javax.validation.constraints.NotBlank;
 
+import org.apache.commons.lang.StringUtils;
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
 import org.sonatype.nexus.blobstore.rest.BlobStoreApiSoftQuota;
 import org.sonatype.nexus.common.collect.NestedAttributesMap;
 
 import io.swagger.annotations.ApiModelProperty;
 
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.LOCATION_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.*;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.TYPE_KEY;
@@ -47,6 +46,9 @@ public class GoogleCloudBlobstoreApiModel
   @ApiModelProperty("Settings to control the soft quota.")
   private BlobStoreApiSoftQuota softQuota;
 
+  @ApiModelProperty("Path to the Google Application Credentials file")
+  private String credentialFilePath;
+
   public GoogleCloudBlobstoreApiModel() {
   }
 
@@ -54,6 +56,9 @@ public class GoogleCloudBlobstoreApiModel
     this.name = configuration.getName();
     this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_KEY, String.class);
     this.region = configuration.attributes(CONFIG_KEY).get(LOCATION_KEY, String.class);
+    if (StringUtils.isNotBlank(configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class))) {
+      this.credentialFilePath = "<path is configured>";
+    };
 
     NestedAttributesMap softQuotaAttributes = configuration.attributes(ROOT_KEY);
     if (softQuotaAttributes != null) {
@@ -94,5 +99,13 @@ public class GoogleCloudBlobstoreApiModel
 
   public void setSoftQuota(final BlobStoreApiSoftQuota softQuota) {
     this.softQuota = softQuota;
+  }
+
+  public String getCredentialFilePath() {
+    return credentialFilePath;
+  }
+
+  public void setCredentialFilePath(String credentialFilePath) {
+    this.credentialFilePath = credentialFilePath;
   }
 }

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -39,9 +39,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.BUCKET_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.LOCATION_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.*;
 import static org.sonatype.nexus.blobstore.gcloud.internal.rest.GoogleCloudBlobstoreApiResource.RESOURCE_URI;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
@@ -143,6 +141,7 @@ public class GoogleCloudBlobstoreApiResource
     NestedAttributesMap bucket = config.attributes(CONFIG_KEY);
     bucket.set(BUCKET_KEY, blobstoreApiModel.getBucketName());
     bucket.set(LOCATION_KEY, blobstoreApiModel.getRegion());
+    bucket.set(CREDENTIAL_FILE_KEY, blobstoreApiModel.getCredentialFilePath());
 
     if (blobstoreApiModel.getSoftQuota() != null ) {
       NestedAttributesMap softQuota = config.attributes(ROOT_KEY);

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
@@ -1,0 +1,69 @@
+package org.sonatype.nexus.blobstore.gcloud.internal
+
+import org.sonatype.nexus.blobstore.MockBlobStoreConfiguration
+import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport
+import org.sonatype.nexus.blobstore.quota.internal.SpaceUsedQuota
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+class GoogleCloudStorageFactoryTest extends Specification
+{
+    private GoogleCloudStorageFactory factory = new GoogleCloudStorageFactory()
+
+    def setupSpec() {
+        def key = "GOOGLE_APPLICATION_CREDENTIALS"
+        System.out.println(key + "" + System.getenv(key))
+    }
+
+    def "create default" () {
+        given:
+            MockBlobStoreConfiguration config = makeConfig('default', null)
+        expect:
+            factory.create(config)
+    }
+
+    @IgnoreIf({ getClass().getResource('/gce-credentials.json') == null })
+    def "successful create with valid file path"() {
+        given:
+            MockBlobStoreConfiguration config = makeConfig('with-valid-path', '/gce-credentials.json')
+        expect:
+            factory.create(config)
+    }
+
+    def "ignores invalid credential file path"() {
+        given:
+            MockBlobStoreConfiguration config = makeConfig('with-invalid-path', 'this-file-doesnt-exist')
+        expect:
+            factory.create(config)
+    }
+
+    def "ignores invalid credential file content"() {
+        given:
+            MockBlobStoreConfiguration config = makeConfig('invalid-content', '/.gce-credentials-example.json')
+        when:
+            factory.create(config)
+        then:
+            thrown(IOException)
+    }
+
+    def makeConfig(String name, String credentialFilePath) {
+        MockBlobStoreConfiguration config = new MockBlobStoreConfiguration()
+        def credentialUrl = null
+        if (credentialFilePath != null) {
+            credentialUrl = this.getClass().getResource(credentialFilePath)?.getFile()
+        }
+        config.name = name
+        config.attributes = [
+                'google cloud storage': [
+                        bucket: 'test-bucket-name',
+                        location: 'us-central1',
+                        credential_file: credentialUrl
+                ],
+                (BlobStoreQuotaSupport.ROOT_KEY): [
+                        (BlobStoreQuotaSupport.TYPE_KEY): (SpaceUsedQuota.ID),
+                        (BlobStoreQuotaSupport.LIMIT_KEY): 512000L
+                ]
+        ]
+        return config
+    }
+}

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
@@ -10,11 +10,6 @@ class GoogleCloudStorageFactoryTest extends Specification
 {
     private GoogleCloudStorageFactory factory = new GoogleCloudStorageFactory()
 
-    def setupSpec() {
-        def key = "GOOGLE_APPLICATION_CREDENTIALS"
-        System.out.println(key + "" + System.getenv(key))
-    }
-
     def "create default" () {
         given:
             MockBlobStoreConfiguration config = makeConfig('default', null)

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -80,8 +80,27 @@ class GoogleCloudBlobstoreApiResourceTest
       thrown(WebApplicationMessageException)
   }
 
+  def "merge handles credential_file"() {
+    given:
+      GoogleCloudBlobstoreApiModel model = new GoogleCloudBlobstoreApiModel();
+      model.setBucketName('bucketname')
+      model.setName('blobstorename')
+      model.setRegion('us-central1')
+      model.setCredentialFilePath('/path/to/a/file')
+      MockBlobStoreConfiguration config = new MockBlobStoreConfiguration()
+
+    when:
+      api.merge(config, model)
+
+    then:
+      config.attributes('google cloud storage').get('bucket') == model.bucketName
+      config.attributes('google cloud storage').get('location') == model.region
+      config.attributes('google cloud storage').get('credential_file') == model.credentialFilePath
+      config.name == model.name
+  }
+
   def makeConfig(String name) {
-    BlobStoreConfiguration result = new MockBlobStoreConfiguration()
+    MockBlobStoreConfiguration result = new MockBlobStoreConfiguration()
     result.name = name
     result.type = GoogleCloudBlobStore.TYPE
     result.attributes = [

--- a/nexus-blobstore-google-cloud/src/test/resources/invalid-credential-file.json
+++ b/nexus-blobstore-google-cloud/src/test/resources/invalid-credential-file.json
@@ -1,0 +1,3 @@
+{
+  "some-key": "some-value"
+}


### PR DESCRIPTION
Original REST implementation missed a passthrough for the attribute.

Fixes: #88.