### PR TITLE
Read the old attribute names but write only the new attribute names

### DIFF
--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobAttributesHelper.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobAttributesHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.blobstore.gcloud.internal;
+
+import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.TYPE;
+
+public class GoogleCloudBlobAttributesHelper
+{
+  public static final String CONFIG_KEY = TYPE.toLowerCase();
+
+  private static final String OLD_BUCKET_KEY = "bucket";
+
+  public static final String BUCKET_KEY = "bucketName";
+
+  private static final String OLD_CREDENTIAL_FILE_KEY = "credential_file";
+
+  public static final String CREDENTIAL_FILE_KEY = "credentialFilePath";
+
+  private static final String OLD_LOCATION_KEY = "location";
+
+  public static final String LOCATION_KEY = "region";
+
+  public static void clearOldAttributes(final BlobStoreConfiguration blobStoreConfiguration) {
+    NestedAttributesMap config = blobStoreConfiguration.attributes(CONFIG_KEY);
+    config.remove(OLD_BUCKET_KEY);
+    config.remove(OLD_LOCATION_KEY);
+    config.remove(OLD_CREDENTIAL_FILE_KEY);
+  }
+
+  public static String requireConfiguredBucketName(final BlobStoreConfiguration blobStoreConfiguration) {
+    return requireNewOrOldKey(blobStoreConfiguration, BUCKET_KEY, OLD_BUCKET_KEY);
+  }
+
+  public static String requireConfiguredRegion(final BlobStoreConfiguration blobStoreConfiguration) {
+    return requireNewOrOldKey(blobStoreConfiguration, LOCATION_KEY, OLD_LOCATION_KEY);
+  }
+
+  public static String getConfiguredCredentialFileLocation(final BlobStoreConfiguration blobStoreConfiguration) {
+    NestedAttributesMap config = blobStoreConfiguration.attributes(CONFIG_KEY);
+    return config.get(CREDENTIAL_FILE_KEY, String.class, config.get(OLD_CREDENTIAL_FILE_KEY, String.class));
+  }
+
+  private static String requireNewOrOldKey(
+      final BlobStoreConfiguration blobStoreConfiguration,
+      final String newKey,
+      final String oldKey)
+  {
+    NestedAttributesMap config = blobStoreConfiguration.attributes(CONFIG_KEY);
+    if (config.contains(newKey)) {
+      return config.get(newKey, String.class);
+    }
+    else if (config.contains(oldKey)) {
+      return config.require(oldKey, String.class);
+    }
+    else {
+      throw new IllegalStateException("Missing attribute " + newKey);
+    }
+  }
+}

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -25,6 +25,10 @@ import org.sonatype.nexus.blobstore.quota.BlobStoreQuotaService;
 import org.sonatype.nexus.formfields.FormField;
 import org.sonatype.nexus.formfields.StringTextFormField;
 
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.BUCKET_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.LOCATION_KEY;
+
 @Named(GoogleCloudBlobStore.TYPE)
 public class GoogleCloudBlobStoreDescriptor
     extends BlobStoreDescriptorSupport
@@ -64,21 +68,21 @@ public class GoogleCloudBlobStoreDescriptor
   public GoogleCloudBlobStoreDescriptor(final BlobStoreQuotaService quotaService) {
     super(quotaService);
     bucket = new StringTextFormField(
-        GoogleCloudBlobStore.BUCKET_KEY,
+        BUCKET_KEY,
         messages.bucketName(),
         messages.bucketHelp(),
         FormField.MANDATORY
     );
 
     location = new StringTextFormField(
-        GoogleCloudBlobStore.LOCATION_KEY,
+        LOCATION_KEY,
         messages.locationName(),
         messages.locationHelp(),
         FormField.MANDATORY
     ).withInitialValue("us-central1");
 
     credentialFile = new StringTextFormField(
-        GoogleCloudBlobStore.CREDENTIAL_FILE_KEY,
+        CREDENTIAL_FILE_KEY,
         messages.credentialPath(),
         messages.credentialHelp(),
         FormField.OPTIONAL

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
@@ -23,8 +23,7 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import org.apache.shiro.util.StringUtils;
 
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.getConfiguredCredentialFileLocation;
 
 @Named
 public class GoogleCloudDatastoreFactory extends AbstractGoogleClientFactory
@@ -33,7 +32,7 @@ public class GoogleCloudDatastoreFactory extends AbstractGoogleClientFactory
   Datastore create(final BlobStoreConfiguration configuration) throws Exception {
     DatastoreOptions.Builder builder = DatastoreOptions.newBuilder().setTransportOptions(transportOptions());
 
-    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);
+    String credentialFile = getConfiguredCredentialFileLocation(configuration);
     if (StringUtils.hasText(credentialFile)) {
       ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream(credentialFile));
       logger.debug("loaded {} from {} for Google Datastore client", credentials, credentialFile);

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
@@ -23,8 +23,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.apache.shiro.util.StringUtils;
 
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.getConfiguredCredentialFileLocation;
 
 @Named
 public class GoogleCloudStorageFactory extends AbstractGoogleClientFactory
@@ -33,7 +32,7 @@ public class GoogleCloudStorageFactory extends AbstractGoogleClientFactory
   Storage create(final BlobStoreConfiguration configuration) throws Exception {
     StorageOptions.Builder builder = StorageOptions.newBuilder().setTransportOptions(transportOptions());
 
-    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);
+    String credentialFile = getConfiguredCredentialFileLocation(configuration);
     if (StringUtils.hasText(credentialFile)) {
       ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream(credentialFile));
       logger.debug("loaded {} from {} for Google storage client", credentials, credentialFile);

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
@@ -21,7 +21,9 @@ import org.sonatype.nexus.common.collect.NestedAttributesMap;
 
 import io.swagger.annotations.ApiModelProperty;
 
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.*;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.requireConfiguredBucketName;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.getConfiguredCredentialFileLocation;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.requireConfiguredRegion;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.TYPE_KEY;
@@ -54,9 +56,9 @@ public class GoogleCloudBlobstoreApiModel
 
   GoogleCloudBlobstoreApiModel(BlobStoreConfiguration configuration) {
     this.name = configuration.getName();
-    this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_KEY, String.class);
-    this.region = configuration.attributes(CONFIG_KEY).get(LOCATION_KEY, String.class);
-    if (StringUtils.isNotBlank(configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class))) {
+    this.bucketName = requireConfiguredBucketName(configuration);
+    this.region = requireConfiguredRegion(configuration);
+    if (StringUtils.isNotBlank(getConfiguredCredentialFileLocation(configuration))) {
       this.credentialFilePath = "<path is configured>";
     };
 

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -29,6 +29,7 @@ import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.blobstore.api.BlobStore;
 import org.sonatype.nexus.blobstore.api.BlobStoreConfiguration;
 import org.sonatype.nexus.blobstore.api.BlobStoreManager;
+import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper;
 import org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore;
 import org.sonatype.nexus.common.collect.NestedAttributesMap;
 import org.sonatype.nexus.rest.Resource;
@@ -39,7 +40,11 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.*;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.BUCKET_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.LOCATION_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobAttributesHelper.clearOldAttributes;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
 import static org.sonatype.nexus.blobstore.gcloud.internal.rest.GoogleCloudBlobstoreApiResource.RESOURCE_URI;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.LIMIT_KEY;
 import static org.sonatype.nexus.blobstore.quota.BlobStoreQuotaSupport.ROOT_KEY;
@@ -139,6 +144,7 @@ public class GoogleCloudBlobstoreApiResource
   void merge(BlobStoreConfiguration config, GoogleCloudBlobstoreApiModel blobstoreApiModel) {
     config.setName(blobstoreApiModel.getName());
     NestedAttributesMap bucket = config.attributes(CONFIG_KEY);
+    clearOldAttributes(config);
     bucket.set(BUCKET_KEY, blobstoreApiModel.getBucketName());
     bucket.set(LOCATION_KEY, blobstoreApiModel.getRegion());
     bucket.set(CREDENTIAL_FILE_KEY, blobstoreApiModel.getCredentialFilePath());

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -93,9 +93,9 @@ class GoogleCloudBlobstoreApiResourceTest
       api.merge(config, model)
 
     then:
-      config.attributes('google cloud storage').get('bucket') == model.bucketName
-      config.attributes('google cloud storage').get('location') == model.region
-      config.attributes('google cloud storage').get('credential_file') == model.credentialFilePath
+      config.attributes('google cloud storage').get('bucketName') == model.bucketName
+      config.attributes('google cloud storage').get('region') == model.region
+      config.attributes('google cloud storage').get('credentialFilePath') == model.credentialFilePath
       config.name == model.name
   }
 


### PR DESCRIPTION
Issue: https://issues.sonatype.org/browse/NEXUS-28348

These changes swap the stored attribute names to match the attribute names used in the rest api. This allows the react UI to use the REST API, while the extjs UI continues to work as before. This could result in different blobstore configurations using different atttribute names, but once they are updated they will use the new names.