### PR TITLE
fix lift bug: MissingOverride, and prep to ignore one

### DIFF
--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -91,6 +91,8 @@ public class GoogleCloudBlobStoreDescriptor
   }
   
   // Normally we would mark this as @Override, but that will cause problems on older nxrm versions
+  // @TODO Revert this, adding to allow us to ignore the lift bug (see comment above)
+  @Override
   public String getId() {
     return "google";
   }

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -91,8 +91,6 @@ public class GoogleCloudBlobStoreDescriptor
   }
   
   // Normally we would mark this as @Override, but that will cause problems on older nxrm versions
-  // @TODO Revert this, adding to allow us to ignore the lift bug (see comment above)
-  @Override
   public String getId() {
     return "google";
   }

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudPropertiesFile.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudPropertiesFile.java
@@ -46,6 +46,7 @@ public class GoogleCloudPropertiesFile
     this.key = checkNotNull(key);
   }
 
+  @Override
   public void load() throws IOException {
     log.debug("Loading properties: {}", key);
 
@@ -55,6 +56,7 @@ public class GoogleCloudPropertiesFile
     }
   }
 
+  @Override
   public void store() throws IOException {
     log.debug("Storing properties: {}", key);
 
@@ -67,6 +69,7 @@ public class GoogleCloudPropertiesFile
     bucket.create(key, buffer);
   }
 
+  @Override
   public boolean exists() throws IOException {
     return bucket.get(key) != null;
   }
@@ -78,6 +81,7 @@ public class GoogleCloudPropertiesFile
     }
   }
 
+  @Override
   public String toString() {
     return getClass().getSimpleName() + "{" +
         "key=" + key +


### PR DESCRIPTION
Add some more missing overrides that were flagged by lift. 

Will also add, then remove one override to allow use to "talk" to lift and tell it to ignore one of the missing overrides.
