### PR TITLE
refactor: migration bucket, location, credential_file attributes

### DIFF
--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStoreDescriptor.java
@@ -64,21 +64,21 @@ public class GoogleCloudBlobStoreDescriptor
   public GoogleCloudBlobStoreDescriptor(final BlobStoreQuotaService quotaService) {
     super(quotaService);
     bucket = new StringTextFormField(
-        GoogleCloudBlobStore.BUCKET_KEY,
+        GoogleCloudBlobStore.BUCKET_NAME_KEY,
         messages.bucketName(),
         messages.bucketHelp(),
         FormField.MANDATORY
     );
 
     location = new StringTextFormField(
-        GoogleCloudBlobStore.LOCATION_KEY,
+        GoogleCloudBlobStore.REGION_KEY,
         messages.locationName(),
         messages.locationHelp(),
         FormField.MANDATORY
     ).withInitialValue("us-central1");
 
     credentialFile = new StringTextFormField(
-        GoogleCloudBlobStore.CREDENTIAL_FILE_KEY,
+        GoogleCloudBlobStore.CREDENTIAL_FILE_PATH_KEY,
         messages.credentialPath(),
         messages.credentialHelp(),
         FormField.OPTIONAL

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudDatastoreFactory.java
@@ -24,7 +24,7 @@ import com.google.cloud.datastore.DatastoreOptions;
 import org.apache.shiro.util.StringUtils;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_PATH_KEY;
 
 @Named
 public class GoogleCloudDatastoreFactory extends AbstractGoogleClientFactory
@@ -33,7 +33,7 @@ public class GoogleCloudDatastoreFactory extends AbstractGoogleClientFactory
   Datastore create(final BlobStoreConfiguration configuration) throws Exception {
     DatastoreOptions.Builder builder = DatastoreOptions.newBuilder().setTransportOptions(transportOptions());
 
-    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);
+    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_PATH_KEY, String.class);
     if (StringUtils.hasText(credentialFile)) {
       ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream(credentialFile));
       logger.debug("loaded {} from {} for Google Datastore client", credentials, credentialFile);

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactory.java
@@ -24,7 +24,7 @@ import com.google.cloud.storage.StorageOptions;
 import org.apache.shiro.util.StringUtils;
 
 import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CONFIG_KEY;
-import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_KEY;
+import static org.sonatype.nexus.blobstore.gcloud.internal.GoogleCloudBlobStore.CREDENTIAL_FILE_PATH_KEY;
 
 @Named
 public class GoogleCloudStorageFactory extends AbstractGoogleClientFactory
@@ -33,7 +33,7 @@ public class GoogleCloudStorageFactory extends AbstractGoogleClientFactory
   Storage create(final BlobStoreConfiguration configuration) throws Exception {
     StorageOptions.Builder builder = StorageOptions.newBuilder().setTransportOptions(transportOptions());
 
-    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class);
+    String credentialFile = configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_PATH_KEY, String.class);
     if (StringUtils.hasText(credentialFile)) {
       ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream(credentialFile));
       logger.debug("loaded {} from {} for Google storage client", credentials, credentialFile);

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiModel.java
@@ -54,9 +54,9 @@ public class GoogleCloudBlobstoreApiModel
 
   GoogleCloudBlobstoreApiModel(BlobStoreConfiguration configuration) {
     this.name = configuration.getName();
-    this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_KEY, String.class);
-    this.region = configuration.attributes(CONFIG_KEY).get(LOCATION_KEY, String.class);
-    if (StringUtils.isNotBlank(configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_KEY, String.class))) {
+    this.bucketName = configuration.attributes(CONFIG_KEY).get(BUCKET_NAME_KEY, String.class);
+    this.region = configuration.attributes(CONFIG_KEY).get(REGION_KEY, String.class);
+    if (StringUtils.isNotBlank(configuration.attributes(CONFIG_KEY).get(CREDENTIAL_FILE_PATH_KEY, String.class))) {
       this.credentialFilePath = "<path is configured>";
     };
 

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResource.java
@@ -139,9 +139,9 @@ public class GoogleCloudBlobstoreApiResource
   void merge(BlobStoreConfiguration config, GoogleCloudBlobstoreApiModel blobstoreApiModel) {
     config.setName(blobstoreApiModel.getName());
     NestedAttributesMap bucket = config.attributes(CONFIG_KEY);
-    bucket.set(BUCKET_KEY, blobstoreApiModel.getBucketName());
-    bucket.set(LOCATION_KEY, blobstoreApiModel.getRegion());
-    bucket.set(CREDENTIAL_FILE_KEY, blobstoreApiModel.getCredentialFilePath());
+    bucket.set(BUCKET_NAME_KEY, blobstoreApiModel.getBucketName());
+    bucket.set(REGION_KEY, blobstoreApiModel.getRegion());
+    bucket.set(CREDENTIAL_FILE_PATH_KEY, blobstoreApiModel.getCredentialFilePath());
 
     if (blobstoreApiModel.getSoftQuota() != null ) {
       NestedAttributesMap softQuota = config.attributes(ROOT_KEY);

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudStorageFactoryTest.groovy
@@ -62,9 +62,9 @@ class GoogleCloudStorageFactoryTest extends Specification
         config.name = name
         config.attributes = [
                 'google cloud storage': [
-                        bucket: 'test-bucket-name',
-                        location: 'us-central1',
-                        credential_file: credentialUrl
+                        bucketName: 'test-bucket-name',
+                        region: 'us-central1',
+                        credentialFilePath: credentialUrl
                 ],
                 (BlobStoreQuotaSupport.ROOT_KEY): [
                         (BlobStoreQuotaSupport.TYPE_KEY): (SpaceUsedQuota.ID),

--- a/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
+++ b/nexus-blobstore-google-cloud/src/test/java/org/sonatype/nexus/blobstore/gcloud/internal/rest/GoogleCloudBlobstoreApiResourceTest.groovy
@@ -93,9 +93,9 @@ class GoogleCloudBlobstoreApiResourceTest
       api.merge(config, model)
 
     then:
-      config.attributes('google cloud storage').get('bucket') == model.bucketName
-      config.attributes('google cloud storage').get('location') == model.region
-      config.attributes('google cloud storage').get('credential_file') == model.credentialFilePath
+      config.attributes('google cloud storage').get('bucketName') == model.bucketName
+      config.attributes('google cloud storage').get('region') == model.region
+      config.attributes('google cloud storage').get('credentialFilePath') == model.credentialFilePath
       config.name == model.name
   }
 
@@ -105,8 +105,8 @@ class GoogleCloudBlobstoreApiResourceTest
     result.type = GoogleCloudBlobStore.TYPE
     result.attributes = [
         'google cloud storage': [
-            bucket: 'bucketname',
-            location: 'us-central1'
+            bucketName: 'bucketname',
+            region: 'us-central1'
         ],
         (BlobStoreQuotaSupport.ROOT_KEY): [
             (BlobStoreQuotaSupport.TYPE_KEY): (SpaceUsedQuota.ID),


### PR DESCRIPTION
As of NXRM 3.34, the blobstore UI forms expect attributes with specific names; for cloud blobstores, specifically 'bucketName', 'region', and 'credentialFilePath'. In this changeset, a handler is added to the doInit function on the blobstore that detects the presence of attributes using the legacy forms ('bucket', 'location', and 'credential_file', respectively). New Google Cloud Blobstores will be created using the new attribute names.

Inspired by #99, this preserves the desired optional/required characteristics of the original attributes.

Co-authored-by: Michael Martz <mmartz@sonatype.com>

