### PR TITLE
chore: update to Nexus Repository 3.42

### DIFF
--- a/nexus-blobstore-google-cloud-it/pom.xml
+++ b/nexus-blobstore-google-cloud-it/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-blobstore-google-cloud-parent</artifactId>
-    <version>0.41.1-SNAPSHOT</version>
+    <version>0.42.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud-it</artifactId>

--- a/nexus-blobstore-google-cloud/Dockerfile
+++ b/nexus-blobstore-google-cloud/Dockerfile
@@ -1,9 +1,9 @@
 # Dockerfile to support local development against snapshot builds
-ARG NEXUS_VERSION=3.41.1
+ARG NEXUS_VERSION=3.42.0
 
 FROM sonatype/nexus3:$NEXUS_VERSION
 
-ARG PLUGIN_VERSION=0.41.0-SNAPSHOT
+ARG PLUGIN_VERSION=0.42.0-SNAPSHOT
 ARG BUNDLE_NAME=nexus-blobstore-google-cloud-${PLUGIN_VERSION}.kar
 COPY ./target/${BUNDLE_NAME} /opt/sonatype/nexus/deploy
 RUN mkdir -p /opt/sonatype/sonatype-work/nexus3/etc && \

--- a/nexus-blobstore-google-cloud/pom.xml
+++ b/nexus-blobstore-google-cloud/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-blobstore-google-cloud-parent</artifactId>
-    <version>0.41.1-SNAPSHOT</version>
+    <version>0.42.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud</artifactId>

--- a/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
+++ b/nexus-blobstore-google-cloud/src/main/java/org/sonatype/nexus/blobstore/gcloud/internal/GoogleCloudBlobStore.java
@@ -383,12 +383,6 @@ public class GoogleCloudBlobStore
 
   @Override
   @Guarded(by = STARTED)
-  public void compact() {
-    compact(null);
-  }
-
-  @Override
-  @Guarded(by = STARTED)
   public void doCompact(@Nullable final BlobStoreUsageChecker blobStoreUsageChecker) {
     log.info("Begin deleted blobs processing");
     ProgressLogIntervalHelper progressLogger = new ProgressLogIntervalHelper(log, 60);

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,11 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.41.1-01</version>
+    <version>3.42.0-01</version>
   </parent>
 
   <artifactId>nexus-blobstore-google-cloud-parent</artifactId>
-  <version>0.41.1-SNAPSHOT</version>
+  <version>0.42.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -48,7 +48,7 @@
   <properties>
     <google-cloud-datastore.version>1.99.0</google-cloud-datastore.version>
     <google-cloud-storage.version>1.118.1</google-cloud-storage.version>
-    <nxrm-version>3.41.1-01</nxrm-version>
+    <nxrm-version>3.42.0-01</nxrm-version>
     <clm.skip>true</clm.skip>
     <clm.applicationId>nexus-blobstore-google-cloud</clm.applicationId>
   </properties>


### PR DESCRIPTION
Minor API change - no arg `compact()` method no longer required. Should not impact any functionality.
