### PR TITLE
Fix broken docs for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To build the project and generate the bundle use Maven:
 
     mvn clean package
     
-Optional: review the [additional documentation to configure and run integration tests](src/test/resources/README.md).
+Optional: review the [additional documentation to configure and run integration tests](nexus-blobstore-google-cloud/src/test/resources/README.md).
 
 Running a local development instance
 ------------------------------------


### PR DESCRIPTION
The README appears just to be for the IT in the plugin not the ones in the -it project which likely needs some more setup.

see: #129

(brief, plain English overview of your changes here)

This pull request makes the following changes:
* Fix broken doc for how to run tests for the plugin
