### PR TITLE
English has a capital E

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-(brief, plain english overview of your changes here)
+(brief, plain English overview of your changes here)
 
 This pull request makes the following changes:
 * (your change here)


### PR DESCRIPTION
(brief, plain English overview of your changes here)

This pull request makes the following changes:
* Changes this PR template so that `english` (sic) is correctly capatalized as `Engish` as it is a proper noun.
